### PR TITLE
fix: stabilise simulation tests and compositor fallback

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,24 @@
+"""Pytest configuration ensuring local packages are importable.
+
+This repository hosts multiple python packages that rely on being
+importable without installation.  The tests expect the `src/`
+namespace as well as the simulation utilities under
+`driftlock_choir_sim/` to be directly importable.  When pytest is
+invoked from the repository root the interpreter only sees the current
+working directory, so we extend ``sys.path`` to include those module
+roots."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent
+SRC_ROOT = REPO_ROOT / "src"
+SIM_ROOT = REPO_ROOT / "driftlock_choir_sim"
+
+for path in (SIM_ROOT, SRC_ROOT):
+    if path.is_dir():
+        str_path = str(path)
+        if str_path not in sys.path:
+            sys.path.insert(0, str_path)

--- a/driftlock_choir_sim/sims/test_crlb_fix.py
+++ b/driftlock_choir_sim/sims/test_crlb_fix.py
@@ -1,377 +1,100 @@
-#!/usr/bin/env python3
-"""Test script to verify CRLB fix and consistency.
-
-This script tests the corrected CRLB implementation to ensure it produces
-realistic bounds (1-3× efficiency) instead of the previous 463× unrealistic values.
-"""
-
 from __future__ import annotations
 
 import numpy as np
-import matplotlib.pyplot as plt
-from pathlib import Path
+import pytest
 
 from src.metrics.crlb import CRLBParams, JointCRLBCalculator
 from driftlock_choir_sim.dsp.tx_comb import generate_comb
 from driftlock_choir_sim.dsp.rx_coherent import (
-    estimate_tone_phasors, unwrap_phase, wls_delay, traditional_wls_delay,
-    per_tone_snr, estimate_noise_power
+    estimate_tone_phasors,
+    estimate_noise_power,
+    per_tone_snr,
 )
 from driftlock_choir_sim.dsp.time_delay import impose_fractional_delay_fft
-from driftlock_choir_sim.dsp.impairments import apply_cfo, apply_phase_noise
 from driftlock_choir_sim.dsp.channel_models import awgn
 
 
-OUTPUT_DIR = Path("outputs/crlb_fix_test")
-FIGURES_DIR = OUTPUT_DIR / "figures"
+def _make_simple_observation() -> tuple[np.ndarray, np.ndarray, np.ndarray, float, float, float]:
+    """Synthesize a small comb observation with a known delay."""
+    fs = 200_000.0
+    duration = 0.002  # two milliseconds keeps the FFT sizes tiny
+    df = 5_000.0
+    m = 5
+    truth_tau = 4e-8
+    rng = np.random.default_rng(1234)
 
-
-def ensure_output_dirs():
-    """Create output directories if they don't exist."""
-    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
-    FIGURES_DIR.mkdir(parents=True, exist_ok=True)
-
-
-def test_crlb_consistency():
-    """Test CRLB consistency with realistic parameters."""
-    print("Testing CRLB Consistency...")
-
-    # Test parameters
-    fs = 20e6
-    duration = 9e-3
-    df = 1e6
-    m = 21
-    carrier_freq = 2.4e9  # 2.4 GHz carrier
-    n_trials = 50
-
-    # CRLB parameters
-    crlb_params = CRLBParams(
-        snr_db=30.0,  # 30 dB SNR
-        bandwidth=df * m,  # Total bandwidth
-        duration=duration,
-        carrier_freq=carrier_freq,
-        sample_rate=fs,
-        pulse_shape='rect'
+    x, fk, *_ = generate_comb(
+        fs,
+        duration,
+        df,
+        m=m,
+        omit_fundamental=True,
+        rng=rng,
+        return_payload=False,
     )
-
-    calculator = JointCRLBCalculator(crlb_params)
-
-    # Test 1: Basic CRLB computation
-    print("  1. Computing theoretical CRLB...")
-    crlb_results = calculator.compute_joint_crlb()
-
-    delay_crlb_std = crlb_results['delay_crlb_std']  # seconds
-    freq_crlb_std = crlb_results['frequency_crlb_std']  # Hz
-
-    print(f"     Delay CRLB: {delay_crlb_std*1e12:.2f} ps")
-    print(f"     Frequency CRLB: {freq_crlb_std:.2f} Hz")
-
-    # Test 2: Monte Carlo simulation for comparison
-    print("  2. Running Monte Carlo simulation...")
-    mc_delay_rmse = []
-    mc_freq_rmse = []
-    ls_covariances = []
-
-    for trial in range(n_trials):
-        rng = np.random.default_rng(1000 + trial)
-
-        # Generate test signal
-        x, fk, pilot_mask, _ = generate_comb(
-            fs, duration, df, m=m, omit_fundamental=True, rng=rng, return_payload=True
-        )
-
-        # Apply impairments
-        truth_tau = 5e-12  # 5 ps timing offset
-        truth_df = 500e3   # 500 kHz frequency offset
-
-        x = impose_fractional_delay_fft(x, fs, truth_tau)
-        x = apply_cfo(x, fs, truth_df / fs)
-        x = apply_phase_noise(x, 0.0, rng)
-        x = awgn(x, 30.0, rng)  # 30 dB SNR
-
-        # Estimate timing
-        Yk = estimate_tone_phasors(x, fs, fk)
-        noise_power = estimate_noise_power(x, fs, fk, Yk)
-        snr_per_tone = per_tone_snr(Yk, noise_power, len(x))
-
-        tau_est, ci = wls_delay(Yk, fk, snr_per_tone)
-        # For this test, we'll use a simplified covariance estimate
-        # In practice, this would come from the LS fit
-        covariance = np.array([[1e-12, 0], [0, 1e6]])  # Placeholder
-
-        # Store results
-        mc_delay_rmse.append(abs(tau_est - truth_tau))
-        # For this test, we'll focus on timing estimation only
-        # Frequency offset estimation would require a different approach
-        mc_freq_rmse.append(0)  # Placeholder
-        ls_covariances.append(covariance)
-
-    # Calculate MC statistics
-    mc_delay_rmse_val = np.sqrt(np.mean(np.array(mc_delay_rmse) ** 2))
-    mc_freq_rmse_val = np.sqrt(np.mean(np.array(mc_freq_rmse) ** 2))
-    avg_ls_covariance = np.mean(ls_covariances, axis=0)
-
-    print(f"     MC Delay RMSE: {mc_delay_rmse_val*1e12:.2f} ps")
-    print(f"     MC Frequency RMSE: {mc_freq_rmse_val:.2f} Hz")
-    print(f"     LS Delay Variance: {avg_ls_covariance[0,0]*1e24:.2f} ps²")
-    print(f"     LS Frequency Variance: {avg_ls_covariance[1,1]:.2f} Hz²")
-
-    # Test 3: Consistency analysis
-    print("  3. Analyzing consistency...")
-    consistency = calculator.verify_crlb_consistency(mc_delay_rmse_val, mc_freq_rmse_val, avg_ls_covariance)
-
-    delay_efficiency = consistency['mc_efficiency_delay']
-    freq_efficiency = consistency['mc_efficiency_freq']
-    crlb_consistent = consistency['crlb_consistent']
-    mc_reasonable = consistency['mc_reasonable']
-
-    print(f"     Delay Efficiency: {delay_efficiency:.3f}×")
-    print(f"     Frequency Efficiency: {freq_efficiency:.3f}×")
-    print(f"     CRLB vs LS Consistent: {crlb_consistent}")
-    print(f"     MC Results Reasonable: {mc_reasonable}")
-
-    # Test 4: CRLB from residuals
-    print("  4. Computing CRLB from LS residuals...")
-    # Get phase residuals from one trial
-    x, fk, pilot_mask, _ = generate_comb(fs, duration, df, m=m, omit_fundamental=True, rng=rng, return_payload=True)
     x = impose_fractional_delay_fft(x, fs, truth_tau)
-    x = apply_cfo(x, fs, truth_df / fs)
-    x = apply_phase_noise(x, 0.0, rng)
     x = awgn(x, 30.0, rng)
 
-    Yk = estimate_tone_phasors(x, fs, fk)
-    noise_power = estimate_noise_power(x, fs, fk, Yk)
-    snr_per_tone = per_tone_snr(Yk, noise_power, len(x))
-
-    # Get phase residuals (this would normally come from the LS fit)
-    # For this test, we'll simulate residuals at tone frequencies
-    t = np.arange(len(x)) / fs
-    true_phases = 2 * np.pi * truth_df * t - 2 * np.pi * carrier_freq * truth_tau
-    measured_phases = np.angle(Yk)
-
-    # Compute true phases at tone frequencies (not full time series)
-    # The tones are at frequencies fk, so we need phases at those specific frequencies
-    tone_indices = np.round(fk / (fs / len(x))).astype(int)
-    # Ensure indices are within bounds
-    tone_indices = np.clip(tone_indices, 0, len(x) - 1)
-    true_phases_at_tones = true_phases[tone_indices]
-    phase_residuals = measured_phases - true_phases_at_tones
-
-    residual_crlb = calculator.compute_crlb_from_residuals(phase_residuals, t, carrier_freq)
-
-    print(f"     Residual-based Delay CRLB: {residual_crlb['delay_crlb_std']*1e12:.2f} ps")
-    print(f"     Residual-based Freq CRLB: {residual_crlb['frequency_crlb_std']:.2f} Hz")
-    print(f"     Estimated Noise Variance: {residual_crlb['noise_variance_estimate']:.2e}")
-
-    return {
-        'crlb_results': crlb_results,
-        'mc_results': {
-            'delay_rmse_ps': mc_delay_rmse_val * 1e12,
-            'freq_rmse_hz': mc_freq_rmse_val,
-            'delay_variance_ps2': avg_ls_covariance[0,0] * 1e24,
-            'freq_variance_hz2': avg_ls_covariance[1,1]
-        },
-        'consistency': consistency,
-        'residual_crlb': residual_crlb
-    }
+    phasors = estimate_tone_phasors(x, fs, fk)
+    noise_power = estimate_noise_power(x, fs, fk, phasors)
+    snr = per_tone_snr(phasors, noise_power, len(x))
+    return fk, phasors, snr, truth_tau, fs, duration
 
 
-def test_crlb_vs_snr():
-    """Test CRLB behavior across SNR range."""
-    print("\nTesting CRLB vs SNR...")
-
-    # Test parameters
-    fs = 20e6
-    duration = 9e-3
-    df = 1e6
-    m = 21
-    carrier_freq = 2.4e9
-
-    # CRLB parameters
-    crlb_params = CRLBParams(
-        snr_db=30.0,
-        bandwidth=df * m,
+def test_joint_crlb_returns_finite_values() -> None:
+    """The closed-form CRLB computation should yield finite, positive bounds."""
+    fk, *_, fs, duration = _make_simple_observation()
+    params = CRLBParams(
+        snr_db=25.0,
+        bandwidth=float(np.ptp(fk)) or 1.0,
         duration=duration,
-        carrier_freq=carrier_freq,
+        carrier_freq=2.4e9,
         sample_rate=fs,
-        pulse_shape='rect'
+    )
+    calculator = JointCRLBCalculator(params)
+    results = calculator.compute_joint_crlb()
+
+    assert results["delay_crlb_std"] > 0.0
+    assert results["frequency_crlb_std"] > 0.0
+    assert np.isfinite(results["determinant_fim"])
+
+
+@pytest.mark.filterwarnings("ignore:invalid value encountered")
+def test_verify_crlb_consistency_handles_infinite_bounds() -> None:
+    """Even when the CRLB is infinite the helper should return sensible fields."""
+    fk, *_, fs, duration = _make_simple_observation()
+    params = CRLBParams(
+        snr_db=30.0,
+        bandwidth=float(np.ptp(fk)) or 1.0,
+        duration=duration,
+        carrier_freq=2.45e9,
+        sample_rate=fs,
+    )
+    calculator = JointCRLBCalculator(params)
+    baseline = calculator.compute_joint_crlb()
+
+    delay_std = baseline["delay_crlb_std"]
+    freq_std = baseline["frequency_crlb_std"]
+    ls_covariance = np.diag([max(delay_std**2, 1.0), max(freq_std**2, 1.0)])
+
+    consistency = calculator.verify_crlb_consistency(
+        mc_rmse_delay=max(delay_std, 1.0),
+        mc_rmse_freq=max(freq_std, 1.0),
+        ls_covariance=ls_covariance,
     )
 
-    calculator = JointCRLBCalculator(crlb_params)
-
-    # Test SNR range
-    snr_range = np.arange(10, 40, 2)  # 10 to 38 dB
-    crlb_vs_snr = calculator.compute_crlb_vs_snr(snr_range)
-
-    print("  SNR range test completed")
-    print(f"  SNR range: {snr_range[0]} to {snr_range[-1]} dB")
-    # Find index for 30dB (should be at index 10 for range 10-38 step 2)
-    snr_30db_index = np.where(snr_range == 30)[0][0]
-    print(f"  Delay CRLB at 30dB: {crlb_vs_snr['delay_crlb_std'][snr_30db_index]*1e12:.2f} ps")
-    print(f"  Freq CRLB at 30dB: {crlb_vs_snr['frequency_crlb_std'][snr_30db_index]:.2f} Hz")
-
-    return crlb_vs_snr
-
-
-def plot_crlb_results(results, snr_results):
-    """Generate CRLB analysis plots."""
-    print("\nGenerating CRLB Analysis Plots...")
-
-    # Plot 1: CRLB vs SNR
-    fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(15, 6))
-
-    snr_db = snr_results['snr_db']
-    delay_crlb_ps = np.array(snr_results['delay_crlb_std']) * 1e12
-    freq_crlb_hz = np.array(snr_results['frequency_crlb_std'])
-
-    ax1.semilogy(snr_db, delay_crlb_ps, 'b-', linewidth=2, label='Delay CRLB')
-    ax1.set_xlabel('SNR (dB)')
-    ax1.set_ylabel('Delay CRLB (ps)')
-    ax1.set_title('CRLB vs SNR - Delay Estimation')
-    ax1.grid(True, alpha=0.3)
-    ax1.legend()
-
-    ax2.semilogy(snr_db, freq_crlb_hz, 'r-', linewidth=2, label='Frequency CRLB')
-    ax2.set_xlabel('SNR (dB)')
-    ax2.set_ylabel('Frequency CRLB (Hz)')
-    ax2.set_title('CRLB vs SNR - Frequency Estimation')
-    ax2.grid(True, alpha=0.3)
-    ax2.legend()
-
-    plt.tight_layout()
-    plt.savefig(FIGURES_DIR / 'crlb_vs_snr.png', dpi=300, bbox_inches='tight')
-    plt.close()
-
-    # Plot 2: Consistency analysis
-    fig, ax = plt.subplots(figsize=(10, 6))
-
-    consistency = results['consistency']
-
-    labels = ['Delay\nEfficiency', 'Frequency\nEfficiency', 'CRLB vs LS\nConsistency']
-    values = [consistency['mc_efficiency_delay'],
-              consistency['mc_efficiency_freq'],
-              1.0 if consistency['crlb_consistent'] else 0.1]
-    colors = ['blue', 'red', 'green']
-
-    bars = ax.bar(labels, values, color=colors, alpha=0.7)
-    ax.axhline(y=1.0, color='black', linestyle='--', alpha=0.5, label='Target (1×)')
-    ax.axhline(y=2.0, color='gray', linestyle=':', alpha=0.5, label='Reasonable (2×)')
-    ax.axhline(y=0.5, color='gray', linestyle=':', alpha=0.5)
-
-    ax.set_ylabel('Efficiency Ratio')
-    ax.set_title('CRLB Consistency Analysis')
-    ax.set_yscale('log')
-    ax.grid(True, alpha=0.3)
-    ax.legend()
-
-    # Add value labels
-    for bar, value in zip(bars, values):
-        height = bar.get_height()
-        ax.text(bar.get_x() + bar.get_width()/2., height * 1.1,
-                f'{value:.3f}×' if value >= 0.1 else 'N/A',
-                ha='center', va='bottom', fontsize=10)
-
-    try:
-        plt.tight_layout()
-    except UserWarning:
-        pass  # Ignore tight layout warnings
-    plt.savefig(FIGURES_DIR / 'crlb_consistency.png', dpi=150, bbox_inches='tight')
-    plt.close()
-
-
-def generate_crlb_report(results, snr_results):
-    """Generate comprehensive CRLB analysis report."""
-    print("\n" + "="*70)
-    print("CRLB FIX VERIFICATION REPORT")
-    print("="*70)
-
-    crlb_results = results['crlb_results']
-    mc_results = results['mc_results']
-    consistency = results['consistency']
-    residual_crlb = results['residual_crlb']
-
-    print("\n1. THEORETICAL CRLB RESULTS:")
-    print(f"   Delay CRLB: {crlb_results['delay_crlb_std']*1e12:.2f} ps")
-    print(f"   Frequency CRLB: {crlb_results['frequency_crlb_std']:.2f} Hz")
-    print(f"   Cross-correlation: {crlb_results['cross_correlation']:.3f}")
-
-    print("\n2. MONTE CARLO PERFORMANCE:")
-    print(f"   MC Delay RMSE: {mc_results['delay_rmse_ps']:.2f} ps")
-    print(f"   MC Frequency RMSE: {mc_results['freq_rmse_hz']:.2f} Hz")
-    print(f"   LS Delay Variance: {mc_results['delay_variance_ps2']:.2f} ps²")
-    print(f"   LS Frequency Variance: {mc_results['freq_variance_hz2']:.2f} Hz²")
-
-    print("\n3. EFFICIENCY ANALYSIS:")
-    print(f"   Delay Efficiency: {consistency['mc_efficiency_delay']:.3f}×")
-    print(f"   Frequency Efficiency: {consistency['mc_efficiency_freq']:.3f}×")
-    print(f"   CRLB vs LS Ratio (Delay): {consistency['crlb_vs_ls_delay_ratio']:.3f}×")
-    print(f"   CRLB vs LS Ratio (Freq): {consistency['crlb_vs_ls_freq_ratio']:.3f}×")
-
-    print("\n4. CONSISTENCY ASSESSMENT:")
-    print(f"   CRLB vs LS Consistent: {'✅ YES' if consistency['crlb_consistent'] else '❌ NO'}")
-    print(f"   MC Results Reasonable: {'✅ YES' if consistency['mc_reasonable'] else '❌ NO'}")
-    print(f"   Overall Consistent: {'✅ YES' if consistency['overall_consistent'] else '❌ NO'}")
-
-    print("\n5. RESIDUAL-BASED CRLB:")
-    print(f"     Residual-based Delay CRLB: {residual_crlb['delay_crlb_std']*1e12:.2f} ps")
-    print(f"     Residual-based Freq CRLB: {residual_crlb['frequency_crlb_std']:.2f} Hz")
-    print(f"     Estimated Noise Variance: {residual_crlb['noise_variance_estimate']:.2e}")
-    print(f"     Residual RMS: {residual_crlb['residual_rms']:.3f} rad")
-
-    print("\n6. SUCCESS CRITERIA:")
-    crlb_fixed = (consistency['crlb_vs_ls_delay_ratio'] < 10.0 and
-                  consistency['crlb_vs_ls_freq_ratio'] < 10.0)
-    efficiency_reasonable = (0.1 < consistency['mc_efficiency_delay'] < 10.0 and
-                           0.1 < consistency['mc_efficiency_freq'] < 10.0)
-
-    if crlb_fixed:
-        print("   ✅ CRLB FIXED: Realistic bounds achieved (was 463×, now ~1-3×)")
-    else:
-        print("   ❌ CRLB still unrealistic")
-
-    if efficiency_reasonable:
-        print("   ✅ Efficiency reasonable: MC performance close to theoretical bounds")
-    else:
-        print("   ❌ Efficiency still problematic")
-
-    if consistency['overall_consistent']:
-        print("   🎉 OVERALL SUCCESS: CRLB fix verified!")
-    else:
-        print("   ⚠️  NEEDS WORK: Further CRLB refinement required")
-
-    print("\n7. NEXT STEPS:")
-    if consistency['overall_consistent']:
-        print("   • Proceed with super-resolution performance evaluation")
-        print("   • Use corrected CRLB for efficiency analysis")
-        print("   • Implement residual-based CRLB for real-time bounds")
-    else:
-        print("   • Investigate remaining CRLB inconsistencies")
-        print("   • Verify signal model alignment between estimator and CRLB")
-        print("   • Check noise variance estimation accuracy")
-
-    print("="*70)
-
-
-def main():
-    """Run CRLB fix verification tests."""
-    print("Driftlock CRLB Fix Verification")
-    print("Testing corrected CRLB implementation...")
-
-    ensure_output_dirs()
-
-    # Run all tests
-    results = test_crlb_consistency()
-    snr_results = test_crlb_vs_snr()
-
-    # Generate plots
-    plot_crlb_results(results, snr_results)
-
-    # Generate comprehensive report
-    generate_crlb_report(results, snr_results)
-
-    print(f"\nResults saved to: {OUTPUT_DIR}")
-    print(f"Figures saved to: {FIGURES_DIR}")
-
-
-if __name__ == "__main__":
-    main()
+    required_keys = {
+        "mc_efficiency_delay",
+        "mc_efficiency_freq",
+        "crlb_vs_ls_delay_ratio",
+        "crlb_vs_ls_freq_ratio",
+        "crlb_consistent",
+        "mc_reasonable",
+        "overall_consistent",
+    }
+    assert required_keys.issubset(consistency)
+    assert consistency["theoretical_crlb"]["delay_crlb_std"] == delay_std
+    assert consistency["theoretical_crlb"]["frequency_crlb_std"] == freq_std
+    assert isinstance(consistency["crlb_consistent"], (bool, np.bool_))
+    assert isinstance(consistency["mc_reasonable"], (bool, np.bool_))
+    assert isinstance(consistency["overall_consistent"], (bool, np.bool_))

--- a/driftlock_choir_sim/sims/test_phase1_enhancements.py
+++ b/driftlock_choir_sim/sims/test_phase1_enhancements.py
@@ -1,430 +1,81 @@
-#!/usr/bin/env python3
-"""Test script for Phase 1 Choir Lab enhancements.
-
-This script validates the performance improvements achieved through:
-1. Enhanced WLS weighting algorithms (RMSE/CRLB < 0.8)
-2. Optimized multi-carrier comb synthesis
-3. Enhanced aperture detection for sub-0dB SNR
-4. Adaptive frequency offset selection
-
-Run with: python test_phase1_enhancements.py
-"""
-
 from __future__ import annotations
 
-import time
 import numpy as np
-import matplotlib.pyplot as plt
-from pathlib import Path
-from typing import Dict, Any
 
 from driftlock_choir_sim.dsp.tx_comb import generate_comb
 from driftlock_choir_sim.dsp.rx_coherent import (
-    estimate_tone_phasors, unwrap_phase, wls_delay, traditional_wls_delay,
-    per_tone_snr, estimate_noise_power, adaptive_frequency_offset_selection,
-    dynamic_offset_adaptation
+    estimate_tone_phasors,
+    estimate_noise_power,
+    per_tone_snr,
+    traditional_wls_delay,
+    unwrap_phase,
+    wls_delay,
 )
-from driftlock_choir_sim.dsp.rx_aperture import (
-    envelope_spectrum, detect_df_peak_robust, choir_health_index
-)
-from driftlock_choir_sim.dsp.crlb import delay_crlb_rms_bandwidth as delay_crlb_std
 from driftlock_choir_sim.dsp.time_delay import impose_fractional_delay_fft
-from driftlock_choir_sim.dsp.impairments import apply_cfo, apply_phase_noise
 from driftlock_choir_sim.dsp.channel_models import awgn
-from driftlock_choir_sim.dsp.metrics import rms_bandwidth_hz, ber_qpsk_awgn
 
 
-OUTPUT_DIR = Path("driftlock_choir_sim/outputs/phase1_enhancements")
-FIGURES_DIR = OUTPUT_DIR / "figures"
+def _synthesise_measurements(
+    truth_tau: float = 50e-9,
+    snr_db: float = 25.0,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, float]:
+    """Generate a compact tone comb with a deterministic timing offset."""
+    fs = 1e6
+    duration = 0.003
+    df = 10_000.0
+    m = 9
+    rng = np.random.default_rng(2024)
+
+    x, fk, *_ = generate_comb(
+        fs,
+        duration,
+        df,
+        m=m,
+        omit_fundamental=True,
+        rng=rng,
+        return_payload=False,
+    )
+    x = impose_fractional_delay_fft(x, fs, truth_tau)
+    x = awgn(x, snr_db, rng)
+
+    phasors = estimate_tone_phasors(x, fs, fk)
+    phases = unwrap_phase(np.angle(phasors), fk)
+    noise_power = estimate_noise_power(x, fs, fk, phasors)
+    snr = per_tone_snr(phasors, noise_power, len(x))
+    return fk, phases, snr, truth_tau
 
 
-def ensure_output_dirs():
-    """Create output directories if they don't exist."""
-    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
-    FIGURES_DIR.mkdir(parents=True, exist_ok=True)
+def test_enhanced_wls_refines_delay_estimate() -> None:
+    """The enhanced estimator should outperform the traditional weighting."""
+    fk, phases, snr, truth_tau = _synthesise_measurements()
+    traditional_tau, _ = traditional_wls_delay(fk, phases, snr)
+    enhanced_tau, _ = wls_delay(fk, phases, snr)
+
+    assert abs(enhanced_tau - truth_tau) < abs(traditional_tau - truth_tau)
 
 
-def test_enhanced_wls_weighting():
-    """Test enhanced WLS weighting for RMSE/CRLB improvement."""
-    print("Testing Enhanced WLS Weighting...")
+def test_generate_comb_metadata_is_well_formed() -> None:
+    """Comb metadata should describe the emitted tones and payload schedule."""
+    fs = 1e6
+    duration = 0.002
+    df = 8_000.0
+    m = 9
+    rng = np.random.default_rng(7)
 
-    # Test parameters
-    fs = 20e6
-    duration = 9e-3
-    df = 1e6
-    m = 21
-    truth_tau = 100e-12
-    n_trials = 50
-
-    results = {
-        'traditional_rmse': [],
-        'enhanced_rmse': [],
-        'traditional_crlb': [],
-        'enhanced_crlb': [],
-        'traditional_ratios': [],
-        'enhanced_ratios': []
-    }
-
-    for trial in range(n_trials):
-        rng = np.random.default_rng(2025 + trial)
-
-        # Generate test signal
-        x, fk, pilot_mask, _ = generate_comb(
-            fs, duration, df, m=m, omit_fundamental=True, rng=rng, return_payload=True
-        )
-
-        # Apply impairments
-        x = impose_fractional_delay_fft(x, fs, truth_tau)
-        x = apply_cfo(x, fs, 0.0)
-        x = apply_phase_noise(x, 0.0, rng)
-        x = awgn(x, 30.0, rng)  # 30dB SNR
-
-        # Traditional WLS
-        Yk_traditional = estimate_tone_phasors(x, fs, fk)
-        ph_traditional = unwrap_phase(np.angle(Yk_traditional), fk)
-        noise_power = estimate_noise_power(x, fs, fk, Yk_traditional)
-        snr_traditional = per_tone_snr(Yk_traditional, noise_power, len(x))
-
-        tau_traditional, _, crlb_traditional = traditional_wls_delay(
-            fk, ph_traditional, snr_traditional, return_stats=True
-        )
-
-        # Enhanced WLS (our new implementation)
-        tau_enhanced, _, crlb_enhanced = wls_delay(
-            fk, ph_traditional, snr_traditional, return_stats=True
-        )
-
-        # Store results
-        results['traditional_rmse'].append(abs(tau_traditional - truth_tau) * 1e12)
-        results['enhanced_rmse'].append(abs(tau_enhanced - truth_tau) * 1e12)
-        results['traditional_crlb'].append(crlb_traditional * 1e12)
-        results['enhanced_crlb'].append(crlb_enhanced * 1e12)
-
-    # Calculate statistics
-    traditional_rmse = np.mean(results['traditional_rmse'])
-    enhanced_rmse = np.mean(results['enhanced_rmse'])
-    traditional_crlb = np.mean(results['traditional_crlb'])
-    enhanced_crlb = np.mean(results['enhanced_crlb'])
-
-    traditional_ratio = traditional_rmse / traditional_crlb
-    enhanced_ratio = enhanced_rmse / enhanced_crlb
-
-    improvement = (traditional_ratio - enhanced_ratio) / traditional_ratio * 100
-
-    print(f"  Traditional WLS - RMSE: {traditional_rmse:.1f} ps, CRLB: {traditional_crlb:.1f} ps, Ratio: {traditional_ratio:.3f}")
-    print(f"  Enhanced WLS    - RMSE: {enhanced_rmse:.1f} ps, CRLB: {enhanced_crlb:.1f} ps, Ratio: {enhanced_ratio:.3f}")
-    print(f"  Improvement: {improvement:.1f}%")
-
-    return {
-        'traditional_ratio': traditional_ratio,
-        'enhanced_ratio': enhanced_ratio,
-        'improvement_pct': improvement,
-        'target_achieved': enhanced_ratio < 0.8
-    }
-
-
-def test_optimized_comb_synthesis():
-    """Test optimized multi-carrier comb synthesis."""
-    print("\nTesting Optimized Comb Synthesis...")
-
-    # Test parameters
-    fs = 20e6
-    duration = 9e-3
-    df = 1e6
-    m = 21
-
-    # Generate optimized comb
-    x_opt, fk_opt, pilot_mask_opt, meta_opt = generate_comb(
-        fs, duration, df, m=m, omit_fundamental=True, return_payload=True
+    x, fk, pilot_mask, meta = generate_comb(
+        fs,
+        duration,
+        df,
+        m=m,
+        omit_fundamental=True,
+        rng=rng,
+        payload_qpsk_fraction=0.4,
+        return_payload=True,
     )
 
-    # Calculate reconstruction SNR
-    reconstruction_snr = meta_opt.get('reconstruction_snr_db', 0.0)
-
-    # Calculate RMS bandwidth
-    amps = meta_opt.get('amps', np.ones(m))
-    weights = amps ** 2
-    beff_rms = np.sqrt(np.sum(weights * fk_opt**2) / np.sum(weights))
-
-    # PAPR measurement
-    papr_db = 10 * np.log10(np.max(np.abs(x_opt)**2) / np.mean(np.abs(x_opt)**2))
-
-    print(f"  Reconstruction SNR: {reconstruction_snr:.1f} dB")
-    print(f"  RMS Bandwidth: {beff_rms/1e6:.1f} MHz")
-    print(f"  PAPR: {papr_db:.1f} dB")
-
-    return {
-        'reconstruction_snr_db': reconstruction_snr,
-        'rms_bandwidth_mhz': beff_rms / 1e6,
-        'papr_db': papr_db
-    }
-
-
-def test_enhanced_aperture_detection():
-    """Test enhanced aperture detection for sub-0dB SNR."""
-    print("\nTesting Enhanced Aperture Detection...")
-
-    # Test parameters
-    fs = 5e6
-    duration = 0.02
-    df = 10e3
-    m = 5
-    test_snrs = [-5, 0, 5, 10, 15, 20]
-
-    results = {
-        'snr_db': [],
-        'detection_rate': [],
-        'snr_estimate_db': [],
-        'freq_accuracy_hz': []
-    }
-
-    for snr_db in test_snrs:
-        print(f"  Testing SNR = {snr_db} dB...")
-
-        detection_count = 0
-        snr_estimates = []
-        freq_errors = []
-
-        for trial in range(20):
-            rng = np.random.default_rng(3000 + trial)
-
-            # Generate test signal
-            x, fk, _, _ = generate_comb(
-                fs, duration, df, m=m, omit_fundamental=True, rng=rng, return_payload=True
-            )
-
-            # Apply impairments
-            x = awgn(x, snr_db, rng)
-
-            # Enhanced aperture detection
-            peak_freq, peak_snr, quality_metrics = detect_df_peak_robust(
-                x, fs, df, n_averages=3
-            )
-
-            # Check detection success
-            freq_error = abs(peak_freq - df)
-            if freq_error < df * 0.1 and quality_metrics['detection_confidence'] > 0.5:
-                detection_count += 1
-
-            snr_estimates.append(peak_snr)
-            freq_errors.append(freq_error)
-
-        # Store results
-        detection_rate = detection_count / 20.0
-        mean_snr_estimate = np.mean(snr_estimates)
-        mean_freq_error = np.mean(freq_errors)
-
-        results['snr_db'].append(snr_db)
-        results['detection_rate'].append(detection_rate)
-        results['snr_estimate_db'].append(mean_snr_estimate)
-        results['freq_accuracy_hz'].append(mean_freq_error)
-
-        print(f"    Detection Rate: {detection_rate:.1%}, SNR Est: {mean_snr_estimate:.1f} dB, Freq Err: {mean_freq_error:.0f} Hz")
-
-    return results
-
-
-def test_adaptive_frequency_offset():
-    """Test adaptive frequency offset selection."""
-    print("\nTesting Adaptive Frequency Offset Selection...")
-
-    # Test parameters
-    base_freq_hz = 2.4e9  # 2.4 GHz
-    target_precision_ps = 10.0
-    bandwidth_hz = 20e6
-    test_snrs = [10, 20, 30]
-
-    results = []
-
-    for snr_db in test_snrs:
-        print(f"  Testing SNR = {snr_db} dB...")
-
-        # Get optimal offset
-        optimal_offset, expected_precision, metadata = adaptive_frequency_offset_selection(
-            base_freq_hz=base_freq_hz,
-            target_precision_ps=target_precision_ps,
-            bandwidth_hz=bandwidth_hz,
-            snr_db=snr_db
-        )
-
-        print(f"    Optimal Offset: {optimal_offset/1e3:.1f} kHz")
-        print(f"    Expected Precision: {expected_precision:.1f} ps")
-        print(f"    Bandwidth Utilization: {metadata['bandwidth_utilization']:.1%}")
-
-        results.append({
-            'snr_db': snr_db,
-            'optimal_offset_hz': optimal_offset,
-            'expected_precision_ps': expected_precision,
-            'bandwidth_utilization': metadata['bandwidth_utilization']
-        })
-
-    return results
-
-
-def plot_results(wls_results, aperture_results, offset_results):
-    """Generate performance comparison plots."""
-    print("\nGenerating Performance Plots...")
-
-    # WLS Performance Comparison
-    fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(12, 5))
-
-    # RMSE/CRLB Ratio Comparison
-    ax1.bar(['Traditional', 'Enhanced'], [wls_results['traditional_ratio'], wls_results['enhanced_ratio']])
-    ax1.set_ylabel('RMSE/CRLB Ratio')
-    ax1.set_title('WLS Performance Improvement')
-    ax1.axhline(y=0.8, color='r', linestyle='--', alpha=0.7, label='Target: 0.8')
-    ax1.legend()
-    ax1.grid(True, alpha=0.3)
-
-    # Improvement Percentage
-    ax2.pie([wls_results['improvement_pct'], 100 - wls_results['improvement_pct']],
-            labels=['Improvement', 'Remaining'],
-            autopct='%1.1f%%', startangle=90)
-    ax2.set_title('Performance Improvement')
-
-    plt.tight_layout()
-    plt.savefig(FIGURES_DIR / 'wls_performance_improvement.png', dpi=300, bbox_inches='tight')
-    plt.close()
-
-    # Aperture Detection Performance
-    fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(12, 5))
-
-    snr_db = aperture_results['snr_db']
-    detection_rate = aperture_results['detection_rate']
-
-    # Detection Rate vs SNR
-    ax1.plot(snr_db, detection_rate, 'bo-', linewidth=2, markersize=8)
-    ax1.set_xlabel('SNR (dB)')
-    ax1.set_ylabel('Detection Rate')
-    ax1.set_title('Aperture Detection Performance')
-    ax1.grid(True, alpha=0.3)
-    ax1.axvline(x=0, color='r', linestyle='--', alpha=0.7, label='0 dB Threshold')
-    ax1.legend()
-
-    # SNR Estimation Accuracy
-    snr_estimate = aperture_results['snr_estimate_db']
-    ax2.plot(snr_db, snr_estimate, 'ro-', linewidth=2, markersize=8, label='Estimated')
-    ax2.plot(snr_db, snr_db, 'k--', alpha=0.7, label='Ideal')
-    ax2.set_xlabel('True SNR (dB)')
-    ax2.set_ylabel('Estimated SNR (dB)')
-    ax2.set_title('SNR Estimation Accuracy')
-    ax2.legend()
-    ax2.grid(True, alpha=0.3)
-
-    plt.tight_layout()
-    plt.savefig(FIGURES_DIR / 'aperture_detection_performance.png', dpi=300, bbox_inches='tight')
-    plt.close()
-
-    # Adaptive Offset Performance
-    fig, ax = plt.subplots(figsize=(8, 6))
-
-    for result in offset_results:
-        snr_db = result['snr_db']
-        offset_hz = result['optimal_offset_hz']
-        precision_ps = result['expected_precision_ps']
-
-        ax.scatter(snr_db, offset_hz/1e3, s=precision_ps*10, alpha=0.7,
-                  label=f'SNR {snr_db}dB: {offset_hz/1e3:.0f}kHz')
-
-    ax.set_xlabel('SNR (dB)')
-    ax.set_ylabel('Optimal Offset (kHz)')
-    ax.set_title('Adaptive Frequency Offset Selection')
-    ax.grid(True, alpha=0.3)
-    ax.legend()
-
-    plt.tight_layout()
-    plt.savefig(FIGURES_DIR / 'adaptive_offset_selection.png', dpi=300, bbox_inches='tight')
-    plt.close()
-
-
-def generate_performance_report(all_results):
-    """Generate comprehensive performance report."""
-    print("\n" + "="*60)
-    print("PHASE 1 ENHANCEMENT PERFORMANCE REPORT")
-    print("="*60)
-
-    wls_results = all_results['wls']
-    aperture_results = all_results['aperture']
-    offset_results = all_results['offset']
-
-    print("\n1. ENHANCED WLS WEIGHTING:")
-    print(f"   Traditional RMSE/CRLB: {wls_results['traditional_ratio']:.3f}")
-    print(f"   Enhanced RMSE/CRLB:    {wls_results['enhanced_ratio']:.3f}")
-    print(f"   Improvement:           {wls_results['improvement_pct']:.1f}%")
-    print(f"   Target Achieved:       {'✓' if wls_results['target_achieved'] else '✗'}")
-
-    print("\n2. OPTIMIZED COMB SYNTHESIS:")
-    comb_results = all_results['comb']
-    print(f"   Reconstruction SNR:    {comb_results['reconstruction_snr_db']:.1f} dB")
-    print(f"   RMS Bandwidth:         {comb_results['rms_bandwidth_mhz']:.1f} MHz")
-    print(f"   PAPR:                  {comb_results['papr_db']:.1f} dB")
-
-    print("\n3. ENHANCED APERTURE DETECTION:")
-    sub_zero_db_rate = aperture_results['detection_rate'][1]  # SNR = 0 dB
-    print(f"   0 dB SNR Detection:    {sub_zero_db_rate:.1%}")
-    print(f"   -5 dB SNR Detection:   {aperture_results['detection_rate'][0]:.1%}")
-
-    print("\n4. ADAPTIVE FREQUENCY OFFSET:")
-    for result in offset_results:
-        snr = result['snr_db']
-        offset = result['optimal_offset_hz']
-        precision = result['expected_precision_ps']
-        print(f"   SNR {snr:2d}dB: Offset {offset/1e3:4.0f}kHz → {precision:4.1f}ps precision")
-
-    print("\n5. OVERALL ASSESSMENT:")
-    targets_met = sum([
-        wls_results['target_achieved'],
-        comb_results['reconstruction_snr_db'] > 20.0,  # Good reconstruction SNR
-        sub_zero_db_rate > 0.5,  # >50% detection at 0dB
-    ])
-
-    print(f"   Targets Met: {targets_met}/3")
-    print(f"   Overall Status: {'EXCELLENT' if targets_met >= 2 else 'GOOD' if targets_met >= 1 else 'NEEDS_WORK'}")
-
-    print("\n6. RECOMMENDATIONS:")
-    if wls_results['enhanced_ratio'] >= 0.8:
-        print("   - Consider further WLS optimization for sub-0.8 ratio")
-    if sub_zero_db_rate < 0.5:
-        print("   - Enhance aperture detection for better sub-0dB performance")
-    if comb_results['papr_db'] > 10:
-        print("   - Consider PAPR reduction techniques for hardware efficiency")
-
-    print("="*60)
-
-
-def main():
-    """Run all Phase 1 enhancement tests."""
-    print("Driftlock Phase 1 Enhancement Validation")
-    print("Testing Choir Lab optimizations for breakthrough performance...")
-
-    start_time = time.time()
-    ensure_output_dirs()
-
-    # Run all tests
-    all_results = {}
-
-    all_results['wls'] = test_enhanced_wls_weighting()
-    all_results['comb'] = test_optimized_comb_synthesis()
-    all_results['aperture'] = test_enhanced_aperture_detection()
-    all_results['offset'] = test_adaptive_frequency_offset()
-
-    # Generate plots
-    plot_results(all_results['wls'], all_results['aperture'], all_results['offset'])
-
-    # Generate comprehensive report
-    generate_performance_report(all_results)
-
-    # Save detailed results
-    import json
-    results_file = OUTPUT_DIR / 'phase1_enhancement_results.json'
-    with open(results_file, 'w') as f:
-        json.dump(all_results, f, indent=2, default=str)
-
-    elapsed_time = time.time() - start_time
-    print(f"\nValidation completed in {elapsed_time:.1f} seconds")
-    print(f"Results saved to: {results_file}")
-    print(f"Figures saved to: {FIGURES_DIR}")
-
-
-if __name__ == "__main__":
-    main()
+    assert x.shape == (int(round(fs * duration)),)
+    assert pilot_mask.dtype == bool
+    assert meta["amps"].shape == fk.shape
+    assert np.isfinite(meta["reconstruction_snr_db"])
+    assert meta["samples_per_symbol"] >= 1
+    assert np.isclose(np.mean(np.abs(x) ** 2), 1.0, rtol=0.05)

--- a/driftlock_choir_sim/sims/test_phase2_breakthrough.py
+++ b/driftlock_choir_sim/sims/test_phase2_breakthrough.py
@@ -1,419 +1,67 @@
-#!/usr/bin/env python3
-"""Test script for Phase 2 Algorithmic Breakthroughs.
-
-This script validates the closed-form τ/Δf estimator that achieves
-performance beyond the traditional 2× CRLB limit through:
-1. Geometric estimation using complex plane relationships
-2. Algebraic estimation using polynomial root finding
-3. Hybrid approach combining both methods
-4. Joint τ/Δf estimation with optimal information coupling
-
-Run with: python test_phase2_breakthrough.py
-"""
-
 from __future__ import annotations
 
-import time
 import numpy as np
-import matplotlib.pyplot as plt
-from pathlib import Path
-from typing import Dict, Any
+import pytest
 
 from driftlock_choir_sim.dsp.tx_comb import generate_comb
 from driftlock_choir_sim.dsp.rx_coherent import (
-    estimate_tone_phasors, unwrap_phase, wls_delay, traditional_wls_delay,
-    per_tone_snr, estimate_noise_power
-)
-from driftlock_choir_sim.dsp.closed_form_estimator import (
-    closed_form_tau_df_estimator, ClosedFormEstimator
+    estimate_tone_phasors,
+    estimate_noise_power,
+    per_tone_snr,
 )
 from driftlock_choir_sim.dsp.time_delay import impose_fractional_delay_fft
-from driftlock_choir_sim.dsp.impairments import apply_cfo, apply_phase_noise
+from driftlock_choir_sim.dsp.impairments import apply_cfo
 from driftlock_choir_sim.dsp.channel_models import awgn
-
-
-OUTPUT_DIR = Path("driftlock_choir_sim/outputs/phase2_breakthrough")
-FIGURES_DIR = OUTPUT_DIR / "figures"
-
-
-def ensure_output_dirs():
-    """Create output directories if they don't exist."""
-    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
-    FIGURES_DIR.mkdir(parents=True, exist_ok=True)
-
-
-def test_closed_form_breakthrough():
-    """Test the closed-form estimator breakthrough performance."""
-    print("Testing Closed-Form τ/Δf Estimator Breakthrough...")
-
-    # Test parameters
-    fs = 20e6
-    duration = 9e-3
-    df = 1e6
-    m = 21
-    truth_tau = 100e-12  # 100 ps timing offset
-    truth_df = 500e3     # 500 kHz frequency offset
-    n_trials = 100
-
-    methods = ['geometric', 'algebraic', 'hybrid']
-    results = {method: {'rmse_tau': [], 'rmse_df': [], 'crlb_tau': [], 'crlb_df': []}
-               for method in methods}
-
-    for trial in range(n_trials):
-        rng = np.random.default_rng(2025 + trial)
-
-        # Generate test signal
-        x, fk, pilot_mask, _ = generate_comb(
-            fs, duration, df, m=m, omit_fundamental=True, rng=rng, return_payload=True
-        )
-
-        # Apply impairments
-        x = impose_fractional_delay_fft(x, fs, truth_tau)
-        x = apply_cfo(x, fs, truth_df / fs)  # CFO in normalized frequency
-        x = apply_phase_noise(x, 0.0, rng)
-        x = awgn(x, 30.0, rng)  # 30dB SNR
-
-        # Estimate phasors and SNR
-        Yk = estimate_tone_phasors(x, fs, fk)
-        noise_power = estimate_noise_power(x, fs, fk, Yk)
-        snr_per_tone = per_tone_snr(Yk, noise_power, len(x))
-
-        # Test each method
-        for method in methods:
-            tau_est, df_est, stats = closed_form_tau_df_estimator(
-                Yk, fk, snr_per_tone, method=method, return_stats=True
-            )
-
-            # Store results
-            results[method]['rmse_tau'].append(abs(tau_est - truth_tau) * 1e12)  # ps
-            results[method]['rmse_df'].append(abs(df_est - truth_df))  # Hz
-            results[method]['crlb_tau'].append(stats['crlb_tau_ps'])
-            results[method]['crlb_df'].append(stats['crlb_df_hz'])
-
-    # Calculate statistics
-    summary = {}
-    for method in methods:
-        tau_rmse = np.mean(results[method]['rmse_tau'])
-        df_rmse = np.mean(results[method]['rmse_df'])
-        tau_crlb = np.mean(results[method]['crlb_tau'])
-        df_crlb = np.mean(results[method]['crlb_df'])
-
-        tau_ratio = tau_rmse / tau_crlb
-        df_ratio = df_rmse / df_crlb
-
-        summary[method] = {
-            'tau_rmse_ps': tau_rmse,
-            'df_rmse_hz': df_rmse,
-            'tau_crlb_ps': tau_crlb,
-            'df_crlb_hz': df_crlb,
-            'tau_ratio': tau_ratio,
-            'df_ratio': df_ratio
-        }
-
-        method_name = method.capitalize()
-        print(f"  {method_name:8s} - τ: {tau_rmse:.1f} ps (CRLB: {tau_crlb:.1f} ps, Ratio: {tau_ratio:.3f})")
-        print(f"{'':8s}  Δf: {df_rmse/1e3:.1f} kHz (CRLB: {df_crlb/1e3:.1f} kHz, Ratio: {df_ratio:.3f})")
-
-    return summary
-
-
-def test_vs_traditional_methods():
-    """Compare closed-form estimator against traditional WLS methods."""
-    print("\nComparing Against Traditional Methods...")
-
-    # Test parameters
-    fs = 20e6
-    duration = 9e-3
-    df = 1e6
-    m = 21
-    truth_tau = 100e-12
-    n_trials = 50
-
-    methods = {
-        'traditional_wls': 'Traditional WLS',
-        'enhanced_wls': 'Enhanced WLS',
-        'closed_form_hybrid': 'Closed-Form (Hybrid)',
-        'closed_form_geometric': 'Closed-Form (Geometric)'
-    }
-
-    results = {key: {'rmse': [], 'crlb': []} for key in methods.keys()}
-
-    for trial in range(n_trials):
-        rng = np.random.default_rng(3000 + trial)
-
-        # Generate test signal
-        x, fk, pilot_mask, _ = generate_comb(
-            fs, duration, df, m=m, omit_fundamental=True, rng=rng, return_payload=True
-        )
-
-        # Apply impairments
-        x = impose_fractional_delay_fft(x, fs, truth_tau)
-        x = apply_cfo(x, fs, 0.0)
-        x = apply_phase_noise(x, 0.0, rng)
-        x = awgn(x, 25.0, rng)  # 25dB SNR
-
-        # Estimate phasors and SNR
-        Yk = estimate_tone_phasors(x, fs, fk)
-        ph = unwrap_phase(np.angle(Yk), fk)
-        noise_power = estimate_noise_power(x, fs, fk, Yk)
-        snr_per_tone = per_tone_snr(Yk, noise_power, len(x))
-
-        # Traditional WLS
-        tau_trad, _, crlb_trad = traditional_wls_delay(fk, ph, snr_per_tone, return_stats=True)
-        results['traditional_wls']['rmse'].append(abs(tau_trad - truth_tau) * 1e12)
-        results['traditional_wls']['crlb'].append(crlb_trad * 1e12)
-
-        # Enhanced WLS
-        tau_enh, _, crlb_enh = wls_delay(fk, ph, snr_per_tone, return_stats=True)
-        results['enhanced_wls']['rmse'].append(abs(tau_enh - truth_tau) * 1e12)
-        results['enhanced_wls']['crlb'].append(crlb_enh * 1e12)
-
-        # Closed-form methods
-        for cf_method in ['hybrid', 'geometric']:
-            tau_cf, _, stats = closed_form_tau_df_estimator(
-                Yk, fk, snr_per_tone, method=cf_method, return_stats=True
-            )
-            key = f'closed_form_{cf_method}'
-            results[key]['rmse'].append(abs(tau_cf - truth_tau) * 1e12)
-            results[key]['crlb'].append(stats['crlb_tau_ps'])
-
-    # Calculate performance ratios
-    comparison = {}
-    for key, name in methods.items():
-        rmse = np.mean(results[key]['rmse'])
-        crlb = np.mean(results[key]['crlb'])
-        ratio = rmse / crlb
-        comparison[key] = {'rmse_ps': rmse, 'crlb_ps': crlb, 'ratio': ratio, 'name': name}
-
-        print(f"  {name:20s} - RMSE: {rmse:6.1f} ps, CRLB: {crlb:5.1f} ps, Ratio: {ratio:.3f}")
-
-    return comparison
-
-
-def test_frequency_diversity_impact():
-    """Test how frequency diversity affects closed-form estimator performance."""
-    print("\nTesting Frequency Diversity Impact...")
-
-    # Test parameters
-    fs = 20e6
-    duration = 9e-3
-    truth_tau = 100e-12
-    n_trials = 30
-
-    # Different frequency spacings
-    df_values = [100e3, 500e3, 1e6, 2e6, 5e6]
-    methods = ['geometric', 'algebraic', 'hybrid']
-
-    diversity_results = {df: {method: {'ratios': []} for method in methods}
-                         for df in df_values}
-
-    for df in df_values:
-        print(f"  Testing Δf = {df/1e6:.1f} MHz...")
-
-        for trial in range(n_trials):
-            rng = np.random.default_rng(4000 + trial)
-
-            # Generate signal with this frequency spacing
-            x, fk, pilot_mask, _ = generate_comb(
-                fs, duration, df, m=21, omit_fundamental=True, rng=rng, return_payload=True
-            )
-
-            # Apply impairments
-            x = impose_fractional_delay_fft(x, fs, truth_tau)
-            x = apply_cfo(x, fs, 0.0)
-            x = apply_phase_noise(x, 0.0, rng)
-            x = awgn(x, 20.0, rng)  # 20dB SNR
-
-            # Estimate phasors and SNR
-            Yk = estimate_tone_phasors(x, fs, fk)
-            noise_power = estimate_noise_power(x, fs, fk, Yk)
-            snr_per_tone = per_tone_snr(Yk, noise_power, len(x))
-
-            # Test each method
-            for method in methods:
-                tau_est, _, stats = closed_form_tau_df_estimator(
-                    Yk, fk, snr_per_tone, method=method, return_stats=True
-                )
-                ratio = abs(tau_est - truth_tau) * 1e12 / stats['crlb_tau_ps']
-                diversity_results[df][method]['ratios'].append(ratio)
-
-    # Calculate average ratios
-    summary = {}
-    for df in df_values:
-        summary[df] = {}
-        for method in methods:
-            avg_ratio = np.mean(diversity_results[df][method]['ratios'])
-            summary[df][method] = avg_ratio
-            print(f"    {method.capitalize():8s} - Avg Ratio: {avg_ratio:.3f}")
-
-    return summary
-
-
-def plot_breakthrough_results(comparison, diversity_results):
-    """Generate breakthrough performance comparison plots."""
-    print("\nGenerating Breakthrough Performance Plots...")
-
-    # Performance comparison plot
-    fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(15, 6))
-
-    methods = list(comparison.keys())
-    names = [comparison[m]['name'] for m in methods]
-    ratios = [comparison[m]['ratio'] for m in methods]
-
-    # RMSE/CRLB ratios
-    bars1 = ax1.bar(names, ratios)
-    ax1.set_ylabel('RMSE/CRLB Ratio')
-    ax1.set_title('Estimator Performance Comparison')
-    ax1.axhline(y=2.0, color='r', linestyle='--', alpha=0.7, label='2× CRLB Limit')
-    ax1.axhline(y=1.0, color='g', linestyle='--', alpha=0.7, label='1× CRLB (Optimal)')
-    ax1.legend()
-    ax1.grid(True, alpha=0.3)
-
-    # Add value labels on bars
-    for bar, ratio in zip(bars1, ratios):
-        height = bar.get_height()
-        ax1.text(bar.get_x() + bar.get_width()/2., height + 0.01,
-                f'{ratio:.2f}', ha='center', va='bottom', fontsize=10)
-
-    # Frequency diversity impact
-    df_values = list(diversity_results.keys())
-    df_labels = [f'{df/1e6:.1f}' for df in df_values]
-
-    methods = list(list(diversity_results.values())[0].keys())
-
-    for method in methods:
-        ratios = [diversity_results[df][method] for df in df_values]
-        ax2.plot(df_labels, ratios, marker='o', linewidth=2, markersize=8,
-                label=method.capitalize())
-
-    ax2.set_xlabel('Frequency Spacing (MHz)')
-    ax2.set_ylabel('Average RMSE/CRLB Ratio')
-    ax2.set_title('Frequency Diversity Impact')
-    ax2.legend()
-    ax2.grid(True, alpha=0.3)
-    ax2.axhline(y=2.0, color='r', linestyle='--', alpha=0.7, label='2× CRLB Limit')
-
-    plt.tight_layout()
-    plt.savefig(FIGURES_DIR / 'phase2_breakthrough_performance.png', dpi=300, bbox_inches='tight')
-    plt.close()
-
-    # Breakthrough achievement plot
-    fig, ax = plt.subplots(figsize=(10, 6))
-
-    # Show the breakthrough: sub-2× CRLB performance
-    breakthrough_methods = ['Closed-Form (Hybrid)', 'Closed-Form (Geometric)']
-    breakthrough_ratios = [comparison['closed_form_hybrid']['ratio'],
-                          comparison['closed_form_geometric']['ratio']]
-
-    bars = ax.bar(breakthrough_methods, breakthrough_ratios, color=['#2E86C1', '#A23B72'])
-    ax.set_ylabel('RMSE/CRLB Ratio')
-    ax.set_title('BREAKTHROUGH: Sub-2× CRLB Performance Achieved!')
-    ax.axhline(y=2.0, color='r', linestyle='--', alpha=0.7, label='Traditional Limit')
-    ax.axhline(y=1.0, color='g', linestyle='--', alpha=0.7, label='Information Limit')
-    ax.legend()
-    ax.grid(True, alpha=0.3)
-
-    # Add breakthrough indicators
-    for i, (bar, ratio) in enumerate(zip(bars, breakthrough_ratios)):
-        height = bar.get_height()
-        improvement = (2.0 - ratio) / 2.0 * 100
-        ax.text(bar.get_x() + bar.get_width()/2., height + 0.05,
-                f'{ratio:.2f}\n({improvement:+.1f}% better)', ha='center', va='bottom', fontsize=11)
-
-    plt.tight_layout()
-    plt.savefig(FIGURES_DIR / 'phase2_breakthrough_achievement.png', dpi=300, bbox_inches='tight')
-    plt.close()
-
-
-def generate_breakthrough_report(all_results):
-    """Generate comprehensive breakthrough performance report."""
-    print("\n" + "="*70)
-    print("PHASE 2 ALGORITHMIC BREAKTHROUGH REPORT")
-    print("="*70)
-
-    comparison = all_results['comparison']
-    diversity = all_results['diversity']
-
-    print("\n1. BREAKTHROUGH PERFORMANCE ACHIEVED:")
-    print("   Traditional WLS methods are limited to ≥2× CRLB performance")
-    print("   Our closed-form estimator achieves SUB-2× CRLB performance!")
-
-    best_method = min(comparison.keys(),
-                     key=lambda k: comparison[k]['ratio'] if k.startswith('closed_form') else float('inf'))
-    best_ratio = comparison[best_method]['ratio']
-    improvement_pct = (2.0 - best_ratio) / 2.0 * 100
-
-    print(f"   Best Performance: {comparison[best_method]['name']}")
-    print(f"   RMSE/CRLB Ratio: {best_ratio:.3f} (< 2.0 breakthrough!)")
-    print(f"   Improvement over 2× CRLB: {improvement_pct:.1f}%")
-
-    print("\n2. METHOD COMPARISON:")
-    for key, data in comparison.items():
-        status = "🚀 BREAKTHROUGH" if data['ratio'] < 2.0 else "Traditional"
-        print(f"   {data['name']:25s} - {data['ratio']:.3f}× CRLB {status}")
-
-    print("\n3. FREQUENCY DIVERSITY ANALYSIS:")
-    for df, methods in diversity.items():
-        print(f"   Δf = {df/1e6:.1f} MHz:")
-        for method, ratio in methods.items():
-            print(f"     {method.capitalize():8s}: {ratio:.3f}× CRLB")
-
-    print("\n4. TECHNICAL ACHIEVEMENTS:")
-    print("   ✓ Joint τ/Δf estimation with optimal information coupling")
-    print("   ✓ Geometric approach using complex plane relationships")
-    print("   ✓ Algebraic approach using polynomial root finding")
-    print("   ✓ Hybrid method combining both approaches")
-    print("   ✓ Information-theoretic optimal weighting schemes")
-    print("   ✓ Beyond 2× CRLB performance breakthrough")
-
-    print("\n5. IMPLICATIONS:")
-    print("   • Timing precision improved by >20% over traditional methods")
-    print("   • Enables sub-10ps precision with existing hardware")
-    print("   • Robust performance across different frequency spacings")
-    print("   • Computationally efficient closed-form solution")
-
-    # Check if breakthrough is achieved
-    breakthrough_achieved = best_ratio < 2.0
-    if breakthrough_achieved:
-        print("   🎉 BREAKTHROUGH CONFIRMED: Sub-2× CRLB performance achieved!")
-    else:
-        print("   ⚠️  Further optimization needed for sub-2× CRLB performance")
-
-    print("="*70)
-
-
-def main():
-    """Run all Phase 2 breakthrough tests."""
-    print("Driftlock Phase 2: Algorithmic Breakthroughs")
-    print("Testing closed-form τ/Δf estimator for beyond 2× CRLB performance...")
-
-    start_time = time.time()
-    ensure_output_dirs()
-
-    # Run all tests
-    all_results = {}
-
-    all_results['breakthrough'] = test_closed_form_breakthrough()
-    all_results['comparison'] = test_vs_traditional_methods()
-    all_results['diversity'] = test_frequency_diversity_impact()
-
-    # Generate plots
-    plot_breakthrough_results(all_results['comparison'], all_results['diversity'])
-
-    # Generate comprehensive report
-    generate_breakthrough_report(all_results)
-
-    # Save detailed results
-    import json
-    results_file = OUTPUT_DIR / 'phase2_breakthrough_results.json'
-    with open(results_file, 'w') as f:
-        json.dump(all_results, f, indent=2, default=str)
-
-    elapsed_time = time.time() - start_time
-    print(f"\nBreakthrough validation completed in {elapsed_time:.1f} seconds")
-    print(f"Results saved to: {results_file}")
-    print(f"Figures saved to: {FIGURES_DIR}")
-
-
-if __name__ == "__main__":
-    main()
+from driftlock_choir_sim.dsp.closed_form_estimator import closed_form_tau_df_estimator
+
+
+def _make_snapshot() -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Create a compact observation with non-zero τ and Δf."""
+    fs = 500_000.0
+    duration = 0.003
+    df = 10_000.0
+    m = 7
+    truth_tau = 40e-9
+    truth_df = 500.0
+    rng = np.random.default_rng(321)
+
+    x, fk, *_ = generate_comb(
+        fs,
+        duration,
+        df,
+        m=m,
+        omit_fundamental=True,
+        rng=rng,
+        return_payload=False,
+    )
+    x = impose_fractional_delay_fft(x, fs, truth_tau)
+    x = apply_cfo(x, fs, truth_df / fs)
+    x = awgn(x, 35.0, rng)
+
+    phasors = estimate_tone_phasors(x, fs, fk)
+    noise_power = estimate_noise_power(x, fs, fk, phasors)
+    snr = per_tone_snr(phasors, noise_power, len(x))
+    return fk, phasors, snr
+
+
+@pytest.mark.parametrize("method", ["geometric", "algebraic", "hybrid"])
+def test_closed_form_estimator_produces_finite_stats(method: str) -> None:
+    """All estimator variants should yield finite estimates and metadata."""
+    fk, phasors, snr = _make_snapshot()
+    tau_est, df_est, stats = closed_form_tau_df_estimator(
+        phasors,
+        fk,
+        snr,
+        method=method,
+        return_stats=True,
+    )
+
+    assert np.isfinite(tau_est)
+    assert np.isfinite(df_est)
+    assert stats["crlb_tau_ps"] > 0.0
+    assert stats["crlb_df_hz"] >= 0.0
+
+    if method == "hybrid":
+        assert stats["method_used"] == "hybrid"
+        assert 0.0 <= stats["weight_geometric"] <= 1.0
+        assert 0.0 <= stats["weight_algebraic"] <= 1.0

--- a/driftlock_choir_sim/sims/test_phase3_ultra_precision.py
+++ b/driftlock_choir_sim/sims/test_phase3_ultra_precision.py
@@ -1,551 +1,65 @@
-#!/usr/bin/env python3
-"""Test script for Phase 3 Ultra-Precision Performance.
-
-This script validates the sub-10ps precision timing estimator that pushes
-beyond traditional performance limits through:
-1. Multi-hypothesis Kalman filtering with sub-picosecond precision
-2. Enhanced phase unwrapping with cycle slip detection
-3. Dynamic bandwidth adaptation for optimal precision
-4. Robust outlier rejection using statistical methods
-5. Multi-resolution analysis for enhanced precision
-
-Run with: python test_phase3_ultra_precision.py
-"""
-
 from __future__ import annotations
 
-import time
 import numpy as np
-import matplotlib.pyplot as plt
-from pathlib import Path
-from typing import Dict, Any
+import pytest
 
-from dsp.tx_comb import generate_comb
-from dsp.rx_coherent import (
-    estimate_tone_phasors, unwrap_phase, wls_delay, traditional_wls_delay,
-    per_tone_snr, estimate_noise_power
+from driftlock_choir_sim.dsp.tx_comb import generate_comb
+from driftlock_choir_sim.dsp.rx_coherent import (
+    estimate_tone_phasors,
+    estimate_noise_power,
+    per_tone_snr,
 )
-from dsp.ultra_precision_estimator import (
-    ultra_precision_timing_estimator, UltraPrecisionEstimator, PrecisionMode
+from driftlock_choir_sim.dsp.ultra_precision_estimator import (
+    PrecisionMode,
+    ultra_precision_timing_estimator,
 )
-from dsp.time_delay import impose_fractional_delay_fft
-from dsp.impairments import apply_cfo, apply_phase_noise
-from dsp.channel_models import awgn
-
-
-OUTPUT_DIR = Path("outputs/phase3_ultra_precision")
-FIGURES_DIR = OUTPUT_DIR / "figures"
-
-
-def ensure_output_dirs():
-    """Create output directories if they don't exist."""
-    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
-    FIGURES_DIR.mkdir(parents=True, exist_ok=True)
-
-
-def test_ultra_precision_performance():
-    """Test ultra-precision estimator performance."""
-    print("Testing Ultra-Precision Timing Estimator...")
-
-    # Test parameters for sub-10ps precision
-    fs = 20e6
-    duration = 9e-3
-    df = 1e6
-    m = 21
-    truth_tau = 5e-12  # 5 ps timing offset (sub-10ps target)
-    truth_df = 500e3   # 500 kHz frequency offset
-    n_trials = 200
-
-    modes = [PrecisionMode.HIGH_PRECISION, PrecisionMode.ROBUST, PrecisionMode.ADAPTIVE]
-    results = {mode: {'rmse_tau': [], 'rmse_df': [], 'precision_achieved': []}
-               for mode in modes}
-
-    for trial in range(n_trials):
-        rng = np.random.default_rng(2025 + trial)
-
-        # Generate test signal
-        x, fk, pilot_mask, _ = generate_comb(
-            fs, duration, df, m=m, omit_fundamental=True, rng=rng, return_payload=True
-        )
-
-        # Apply impairments
-        x = impose_fractional_delay_fft(x, fs, truth_tau)
-        x = apply_cfo(x, fs, truth_df / fs)
-        x = apply_phase_noise(x, 0.0, rng)
-        x = awgn(x, 35.0, rng)  # 35dB SNR for precision testing
-
-        # Estimate phasors and SNR
-        Yk = estimate_tone_phasors(x, fs, fk)
-        noise_power = estimate_noise_power(x, fs, fk, Yk)
-        snr_per_tone = per_tone_snr(Yk, noise_power, len(x))
-
-        # Test each precision mode
-        for mode in modes:
-            try:
-                tau_est, df_est, stats = ultra_precision_timing_estimator(
-                    Yk, fk, snr_per_tone, mode=mode, return_stats=True
-                )
-                print(f"  Ultra-precision estimator succeeded for {mode.value}")
-            except Exception as e:
-                print(f"  Ultra-precision estimator failed for {mode.value}: {e}")
-                # Fallback to traditional method
-                tau_est, df_est = traditional_wls_delay(Yk, fk, snr_per_tone)
-                stats = {'error': str(e)}
-
-            # Store results
-            results[mode]['rmse_tau'].append(abs(tau_est - truth_tau) * 1e12)  # ps
-            results[mode]['rmse_df'].append(abs(df_est - truth_df))  # Hz
-            results[mode]['precision_achieved'].append(
-                abs(tau_est - truth_tau) * 1e12 < 10.0  # Sub-10ps achieved
-            )
-
-    # Calculate statistics
-    summary = {}
-    for mode in modes:
-        tau_rmse = np.mean(results[mode]['rmse_tau'])
-        df_rmse = np.mean(results[mode]['rmse_df'])
-        precision_rate = np.mean(results[mode]['precision_achieved']) * 100
-
-        summary[mode] = {
-            'tau_rmse_ps': tau_rmse,
-            'df_rmse_hz': df_rmse,
-            'precision_rate_pct': precision_rate,
-            'sub_10ps_achieved': tau_rmse < 10.0
-        }
-
-        mode_name = mode.value.replace('_', ' ').title()
-        print(f"  {mode_name:<15s} - τ: {tau_rmse:6.2f} ps, Sub-10ps: {precision_rate:5.1f}%")
-
-    return summary
-
-
-def test_robustness_under_stress():
-    """Test robustness under challenging conditions."""
-    print("\nTesting Robustness Under Stress Conditions...")
-
-    # Test parameters
-    fs = 20e6
-    duration = 9e-3
-    df = 1e6
-    m = 21
-    truth_tau = 5e-12
-    n_trials = 100
-
-    # Challenging conditions to test
-    conditions = {
-        'high_noise': {'snr_db': 15.0, 'phase_noise': 0.1},
-        'multipath': {'snr_db': 25.0, 'multipath_delay': 1e-6},
-        'doppler': {'snr_db': 20.0, 'doppler_shift': 100.0},
-        'interference': {'snr_db': 10.0, 'interference_power': 0.5}
-    }
-
-    modes = [PrecisionMode.HIGH_PRECISION, PrecisionMode.ROBUST, PrecisionMode.ADAPTIVE]
-    robustness_results = {condition: {mode: {'success_rate': 0, 'avg_rmse': 0}
-                                     for mode in modes}
-                         for condition in conditions.keys()}
-
-    for condition, params in conditions.items():
-        print(f"  Testing {condition}...")
-
-        for trial in range(n_trials):
-            rng = np.random.default_rng(3000 + trial)
-
-            # Generate test signal
-            x, fk, pilot_mask, _ = generate_comb(
-                fs, duration, df, m=m, omit_fundamental=True, rng=rng, return_payload=True
-            )
-
-            # Apply impairments based on condition
-            x = impose_fractional_delay_fft(x, fs, truth_tau)
-            x = apply_cfo(x, fs, 0.0)
-            x = apply_phase_noise(x, params.get('phase_noise', 0.0), rng)
-            x = awgn(x, params['snr_db'], rng)
-
-            # Add condition-specific impairments
-            if condition == 'multipath':
-                # Add multipath - simplified
-                x_multipath = np.roll(x, int(params['multipath_delay'] * fs))
-                x = x + 0.3 * x_multipath
-            elif condition == 'doppler':
-                # Add Doppler shift - simplified
-                t = np.arange(len(x)) / fs
-                doppler_phase = 2 * np.pi * params['doppler_shift'] * t**2 / 2
-                x = x * np.exp(1j * doppler_phase)
-            elif condition == 'interference':
-                # Add interference
-                interference = np.random.randn(len(x)) + 1j * np.random.randn(len(x))
-                interference = interference / np.sqrt(2) * np.sqrt(params['interference_power'])
-                x = x + interference
-
-            # Estimate phasors and SNR
-            Yk = estimate_tone_phasors(x, fs, fk)
-            noise_power = estimate_noise_power(x, fs, fk, Yk)
-            snr_per_tone = per_tone_snr(Yk, noise_power, len(x))
-
-            # Test each mode
-            for mode in modes:
-                try:
-                    tau_est, _, stats = ultra_precision_timing_estimator(
-                        Yk, fk, snr_per_tone, mode=mode, return_stats=True
-                    )
-                    print(f"  Ultra-precision estimator succeeded for {mode.value} in {condition}")
-
-                    rmse_ps = abs(tau_est - truth_tau) * 1e12
-                    success = rmse_ps < 50.0  # 50ps threshold for success
-
-                    robustness_results[condition][mode]['success_rate'] += success
-                    robustness_results[condition][mode]['avg_rmse'] += rmse_ps
-
-                except Exception as e:
-                    print(f"  Ultra-precision estimator failed for {mode.value} in {condition}: {e}")
-                    # Count failures
-                    robustness_results[condition][mode]['success_rate'] += 0
-
-        # Calculate final statistics
-        for mode in modes:
-            robustness_results[condition][mode]['success_rate'] /= n_trials
-            robustness_results[condition][mode]['avg_rmse'] /= n_trials
-
-            mode_name = mode.value.replace('_', ' ').title()
-            success_rate = robustness_results[condition][mode]['success_rate'] * 100
-            avg_rmse = robustness_results[condition][mode]['avg_rmse']
-            print(f"    {mode_name:<15s} - Success: {success_rate:5.1f}%, RMSE: {avg_rmse:6.2f} ps")
-
-    return robustness_results
-
-
-def test_precision_modes_comparison():
-    """Compare different precision modes."""
-    print("\nComparing Precision Modes...")
-
-    # Test parameters
-    fs = 20e6
-    duration = 9e-3
-    df = 1e6
-    m = 21
-    truth_tau = 5e-12
-    n_trials = 50
-
-    modes = {
-        'high_precision': PrecisionMode.HIGH_PRECISION,
-        'robust': PrecisionMode.ROBUST,
-        'adaptive': PrecisionMode.ADAPTIVE
-    }
-
-    mode_comparison = {key: {'rmse_ps': [], 'latency_ms': [], 'confidence': []}
-                      for key in modes.keys()}
-
-    for trial in range(n_trials):
-        rng = np.random.default_rng(4000 + trial)
-
-        # Generate test signal
-        x, fk, pilot_mask, _ = generate_comb(
-            fs, duration, df, m=m, omit_fundamental=True, rng=rng, return_payload=True
-        )
-
-        # Apply impairments
-        x = impose_fractional_delay_fft(x, fs, truth_tau)
-        x = apply_cfo(x, fs, 0.0)
-        x = apply_phase_noise(x, 0.0, rng)
-        x = awgn(x, 30.0, rng)  # 30dB SNR
-
-        # Estimate phasors and SNR
-        Yk = estimate_tone_phasors(x, fs, fk)
-        noise_power = estimate_noise_power(x, fs, fk, Yk)
-        snr_per_tone = per_tone_snr(Yk, noise_power, len(x))
-
-        # Test each mode
-        for mode_key, mode in modes.items():
-            start_time = time.time()
-
-            try:
-                tau_est, df_est, stats = ultra_precision_timing_estimator(
-                    Yk, fk, snr_per_tone, mode=mode, return_stats=True
-                )
-                print(f"  Ultra-precision estimator succeeded for {mode_key}")
-            except Exception as e:
-                print(f"  Ultra-precision estimator failed for {mode_key}: {e}")
-                # Fallback to traditional method
-                tau_est, df_est = traditional_wls_delay(Yk, fk, snr_per_tone)
-                stats = {'error': str(e)}
-
-            latency = (time.time() - start_time) * 1000  # Convert to ms
-
-            rmse_ps = abs(tau_est - truth_tau) * 1e12
-            confidence = stats.get('phase_unwrap_confidence', 0.5)
-
-            mode_comparison[mode_key]['rmse_ps'].append(rmse_ps)
-            mode_comparison[mode_key]['latency_ms'].append(latency)
-            mode_comparison[mode_key]['confidence'].append(confidence)
-
-    # Calculate statistics
-    comparison_summary = {}
-    for mode_key, data in mode_comparison.items():
-        avg_rmse = np.mean(data['rmse_ps'])
-        avg_latency = np.mean(data['latency_ms'])
-        avg_confidence = np.mean(data['confidence'])
-        sub_10ps_rate = np.mean(np.array(data['rmse_ps']) < 10.0) * 100
-
-        comparison_summary[mode_key] = {
-            'avg_rmse_ps': avg_rmse,
-            'avg_latency_ms': avg_latency,
-            'avg_confidence': avg_confidence,
-            'sub_10ps_rate_pct': sub_10ps_rate
-        }
-
-        mode_name = mode_key.replace('_', ' ').title()
-        print(f"  {mode_name:<15s} - RMSE: {avg_rmse:6.2f} ps, Latency: {avg_latency:5.2f} ms, Sub-10ps: {sub_10ps_rate:5.1f}%")
-
-    return comparison_summary
-
-
-def plot_ultra_precision_results(performance_results, robustness_results, mode_comparison):
-    """Generate ultra-precision performance plots."""
-    print("\nGenerating Ultra-Precision Performance Plots...")
-
-    # Performance comparison plot
-    fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(15, 6))
-
-    modes = list(performance_results.keys())
-    mode_names = [mode.value.replace('_', ' ').title() for mode in modes]
-    rmse_values = [performance_results[mode]['tau_rmse_ps'] for mode in modes]
-    precision_rates = [performance_results[mode]['precision_rate_pct'] for mode in modes]
-
-    # RMSE comparison
-    bars1 = ax1.bar(mode_names, rmse_values, color=['#FF6B6B', '#4ECDC4', '#45B7D1'])
-    ax1.set_ylabel('RMSE (ps)')
-    ax1.set_title('Ultra-Precision Performance')
-    ax1.axhline(y=10.0, color='r', linestyle='--', alpha=0.7, label='10ps Target')
-    ax1.axhline(y=5.0, color='g', linestyle='--', alpha=0.7, label='5ps Breakthrough')
-    ax1.legend()
-    ax1.grid(True, alpha=0.3)
-
-    # Add value labels
-    for bar, rmse in zip(bars1, rmse_values):
-        height = bar.get_height()
-        ax1.text(bar.get_x() + bar.get_width()/2., height + 0.1,
-                f'{rmse:.2f}', ha='center', va='bottom', fontsize=10)
-
-    # Precision achievement rate
-    bars2 = ax2.bar(mode_names, precision_rates, color=['#FF6B6B', '#4ECDC4', '#45B7D1'])
-    ax2.set_ylabel('Sub-10ps Achievement Rate (%)')
-    ax2.set_title('Precision Success Rate')
-    ax2.axhline(y=90.0, color='g', linestyle='--', alpha=0.7, label='90% Target')
-    ax2.legend()
-    ax2.grid(True, alpha=0.3)
-
-    for bar, rate in zip(bars2, precision_rates):
-        height = bar.get_height()
-        ax2.text(bar.get_x() + bar.get_width()/2., height + 1,
-                f'{rate:.1f}%', ha='center', va='bottom', fontsize=10)
-
-    plt.tight_layout()
-    plt.savefig(FIGURES_DIR / 'phase3_ultra_precision_performance.png', dpi=300, bbox_inches='tight')
-    plt.close()
-
-    # Robustness comparison plot
-    fig, ax = plt.subplots(figsize=(12, 6))
-
-    conditions = list(robustness_results.keys())
-    condition_names = [cond.replace('_', ' ').title() for cond in conditions]
-
-    modes = list(list(robustness_results.values())[0].keys())
-    mode_names = [mode.value.replace('_', ' ').title() for mode in modes]
-
-    x = np.arange(len(conditions))
-    width = 0.25
-
-    for i, mode in enumerate(modes):
-        success_rates = [robustness_results[cond][mode]['success_rate'] * 100
-                        for cond in conditions]
-        ax.bar(x + i*width, success_rates, width,
-               label=mode_names[i], alpha=0.8)
-
-    ax.set_xlabel('Test Condition')
-    ax.set_ylabel('Success Rate (%)')
-    ax.set_title('Robustness Under Stress Conditions')
-    ax.set_xticks(x + width)
-    ax.set_xticklabels(condition_names)
-    ax.legend()
-    ax.grid(True, alpha=0.3)
-    ax.axhline(y=80.0, color='g', linestyle='--', alpha=0.7, label='80% Target')
-
-    plt.tight_layout()
-    plt.savefig(FIGURES_DIR / 'phase3_robustness_comparison.png', dpi=300, bbox_inches='tight')
-    plt.close()
-
-    # Mode comparison plot
-    fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(15, 6))
-
-    mode_keys = list(mode_comparison.keys())
-    mode_names = [key.replace('_', ' ').title() for key in mode_keys]
-
-    # RMSE vs Latency tradeoff
-    rmse_values = [mode_comparison[key]['avg_rmse_ps'] for key in mode_keys]
-    latency_values = [mode_comparison[key]['avg_latency_ms'] for key in mode_keys]
-
-    scatter = ax1.scatter(latency_values, rmse_values, s=100, alpha=0.7)
-    for i, name in enumerate(mode_names):
-        ax1.annotate(name, (latency_values[i], rmse_values[i]),
-                    xytext=(5, 5), textcoords='offset points')
-
-    ax1.set_xlabel('Average Latency (ms)')
-    ax1.set_ylabel('Average RMSE (ps)')
-    ax1.set_title('Precision vs Latency Tradeoff')
-    ax1.grid(True, alpha=0.3)
-
-    # Confidence vs Sub-10ps rate
-    confidence_values = [mode_comparison[key]['avg_confidence'] for key in mode_keys]
-    sub10ps_rates = [mode_comparison[key]['sub_10ps_rate_pct'] for key in mode_keys]
-
-    scatter2 = ax2.scatter(confidence_values, sub10ps_rates, s=100, alpha=0.7)
-    for i, name in enumerate(mode_names):
-        ax2.annotate(name, (confidence_values[i], sub10ps_rates[i]),
-                    xytext=(5, 5), textcoords='offset points')
-
-    ax2.set_xlabel('Average Confidence')
-    ax2.set_ylabel('Sub-10ps Achievement Rate (%)')
-    ax2.set_title('Confidence vs Precision Success')
-    ax2.grid(True, alpha=0.3)
-
-    plt.tight_layout()
-    plt.savefig(FIGURES_DIR / 'phase3_mode_comparison.png', dpi=300, bbox_inches='tight')
-    plt.close()
-
-
-def generate_ultra_precision_report(all_results):
-    """Generate comprehensive ultra-precision performance report."""
-    print("\n" + "="*70)
-    print("PHASE 3 ULTRA-PRECISION PERFORMANCE REPORT")
-    print("="*70)
-
-    performance = all_results['performance']
-    robustness = all_results['robustness']
-    mode_comparison = all_results['mode_comparison']
-
-    print("\n1. SUB-10PS PRECISION ACHIEVEMENT:")
-    print("   Target: Achieve sub-10ps timing precision with >90% success rate")
-
-    best_mode = max(performance.keys(),
-                   key=lambda k: performance[k]['precision_rate_pct'])
-    best_rate = performance[best_mode]['precision_rate_pct']
-    best_rmse = performance[best_mode]['tau_rmse_ps']
-
-    print(f"   Best Performance: {best_mode.value.replace('_', ' ').title()}")
-    print(f"   Average RMSE: {best_rmse:.2f} ps")
-    print(f"   Sub-10ps Success Rate: {best_rate:.1f}%")
-    print(f"   Target Achievement: {'✅ SUCCESS' if best_rate >= 90 else '⚠️ NEEDS_WORK'}")
-
-    print("\n2. PRECISION MODE COMPARISON:")
-    for mode_key, data in mode_comparison.items():
-        mode_name = mode_key.replace('_', ' ').title()
-        rmse = data['avg_rmse_ps']
-        latency = data['avg_latency_ms']
-        sub10ps = data['sub_10ps_rate_pct']
-        confidence = data['avg_confidence']
-
-        print(f"   {mode_name:<15s} - RMSE: {rmse:6.2f} ps, Latency: {latency:5.2f} ms")
-        print(f"   {'':<15s}  Sub-10ps: {sub10ps:5.1f}%, Confidence: {confidence:.3f}")
-
-    print("\n3. ROBUSTNESS UNDER STRESS:")
-    print("   Testing performance under challenging conditions:")
-
-    for condition, modes in robustness.items():
-        condition_name = condition.replace('_', ' ').title()
-        print(f"   {condition_name}:")
-
-        for mode_key, stats in modes.items():
-            mode_name = mode_key.value.replace('_', ' ').title()
-            success_rate = stats['success_rate'] * 100
-            avg_rmse = stats['avg_rmse']
-            print(f"     {mode_name:<15s} - Success: {success_rate:5.1f}%, RMSE: {avg_rmse:6.2f} ps")
-
-    print("\n4. TECHNICAL ACHIEVEMENTS:")
-    print("   ✅ Multi-hypothesis Kalman filtering with sub-picosecond precision")
-    print("   ✅ Enhanced phase unwrapping with cycle slip detection")
-    print("   ✅ Dynamic bandwidth adaptation for optimal precision")
-    print("   ✅ Robust outlier rejection using statistical methods")
-    print("   ✅ Multi-resolution analysis for enhanced precision")
-    print("   ✅ Adaptive precision modes for different operating conditions")
-
-    print("\n5. PERFORMANCE BREAKTHROUGHS:")
-    sub_10ps_achieved = any(data['precision_rate_pct'] >= 90 for data in performance.values())
-    robust_under_stress = any(stats['success_rate'] >= 0.8
-                             for condition in robustness.values()
-                             for stats in condition.values())
-
-    if sub_10ps_achieved:
-        print("   🎉 SUB-10PS PRECISION ACHIEVED!")
-    else:
-        print("   ⚠️  Sub-10ps precision needs further optimization")
-
-    if robust_under_stress:
-        print("   🛡️  ROBUST UNDER STRESS CONDITIONS!")
-    else:
-        print("   ⚠️  Robustness under stress needs improvement")
-
-    print("\n6. NEXT STEPS:")
-    if sub_10ps_achieved:
-        print("   • Continue to Phase 4: Advanced signal processing")
-        print("   • Implement super-resolution techniques")
-        print("   • Real-time hardware optimization")
-    else:
-        print("   • Optimize Kalman filter parameters")
-        print("   • Enhance phase unwrapping algorithms")
-        print("   • Improve outlier rejection mechanisms")
-
-    print("="*70)
-
-
-def main():
-    """Run all Phase 3 ultra-precision tests."""
-    print("Driftlock Phase 3: Ultra-Precision Performance")
-    print("Testing sub-10ps timing precision with robustness...")
-
-    start_time = time.time()
-    ensure_output_dirs()
-
-    # Run all tests
-    all_results = {}
-
-    all_results['performance'] = test_ultra_precision_performance()
-    all_results['robustness'] = test_robustness_under_stress()
-    all_results['mode_comparison'] = test_precision_modes_comparison()
-
-    # Generate plots
-    plot_ultra_precision_results(
-        all_results['performance'],
-        all_results['robustness'],
-        all_results['mode_comparison']
+from driftlock_choir_sim.dsp.time_delay import impose_fractional_delay_fft
+from driftlock_choir_sim.dsp.channel_models import awgn
+
+
+def _snapshot(snr_db: float = 35.0) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    fs = 500_000.0
+    duration = 0.003
+    df = 10_000.0
+    m = 7
+    truth_tau = 20e-9
+    rng = np.random.default_rng(987)
+
+    x, fk, *_ = generate_comb(
+        fs,
+        duration,
+        df,
+        m=m,
+        omit_fundamental=True,
+        rng=rng,
+        return_payload=False,
+    )
+    x = impose_fractional_delay_fft(x, fs, truth_tau)
+    x = awgn(x, snr_db, rng)
+
+    phasors = estimate_tone_phasors(x, fs, fk)
+    noise_power = estimate_noise_power(x, fs, fk, phasors)
+    snr = per_tone_snr(phasors, noise_power, len(x))
+    return fk, phasors, snr
+
+
+@pytest.mark.parametrize(
+    "mode",
+    [PrecisionMode.HIGH_PRECISION, PrecisionMode.ROBUST],
+)
+def test_ultra_precision_estimator_reports_diagnostics(mode: PrecisionMode) -> None:
+    fk, phasors, snr = _snapshot()
+    tau_est, df_est, stats = ultra_precision_timing_estimator(
+        phasors,
+        fk,
+        snr,
+        mode=mode,
+        return_stats=True,
     )
 
-    # Generate comprehensive report
-    generate_ultra_precision_report(all_results)
-
-    # Save detailed results
-    import json
-    results_file = OUTPUT_DIR / 'phase3_ultra_precision_results.json'
-
-    def serialize_for_json(obj):
-        """Convert non-serializable objects to strings for JSON."""
-        if hasattr(obj, 'value'):
-            return obj.value  # Convert enum to string
-        if isinstance(obj, (np.ndarray, np.integer, np.floating)):
-            return obj.item() if hasattr(obj, 'item') else float(obj)
-        if isinstance(obj, PrecisionMode):
-            return obj.value  # Handle PrecisionMode enum specifically
-        if str(type(obj)) == "<class 'driftlock_choir_sim.dsp.ultra_precision_estimator.PrecisionMode'>":
-            return obj.value  # Handle PrecisionMode enum specifically
-        return str(obj)
-
-    with open(results_file, 'w') as f:
-        json.dump(all_results, f, indent=2, default=serialize_for_json)
-
-    elapsed_time = time.time() - start_time
-    print(f"\nUltra-precision validation completed in {elapsed_time:.1f} seconds")
-    print(f"Results saved to: {results_file}")
-    print(f"Figures saved to: {FIGURES_DIR}")
-
-
-if __name__ == "__main__":
-    main()
+    assert np.isfinite(tau_est)
+    assert np.isfinite(df_est)
+    assert stats["precision_mode"] == mode.value
+    assert stats["hypothesis_weights"].ndim == 1
+    assert np.isclose(np.sum(stats["hypothesis_weights"]), 1.0)
+    assert np.isfinite(stats["optimal_bandwidth_hz"])

--- a/driftlock_choir_sim/sims/test_phase4_super_resolution.py
+++ b/driftlock_choir_sim/sims/test_phase4_super_resolution.py
@@ -1,551 +1,67 @@
-#!/usr/bin/env python3
-"""Test script for Phase 4 Super-Resolution Performance.
-
-This script validates advanced super-resolution techniques for achieving
-sub-10ps timing precision through:
-1. MUSIC (Multiple Signal Classification) algorithm
-2. ESPRIT (Estimation of Signal Parameters via Rotational Invariance)
-3. Matrix pencil method for enhanced frequency resolution
-4. Subspace-based methods for improved timing estimation
-5. Compressed sensing approaches for sparse signal reconstruction
-
-Run with: python test_phase4_super_resolution.py
-"""
-
 from __future__ import annotations
 
-import time
 import numpy as np
-import matplotlib.pyplot as plt
-from pathlib import Path
-from typing import Dict, Any
 
 from driftlock_choir_sim.dsp.tx_comb import generate_comb
 from driftlock_choir_sim.dsp.rx_coherent import (
-    estimate_tone_phasors, unwrap_phase, wls_delay, traditional_wls_delay,
-    per_tone_snr, estimate_noise_power
-)
-from driftlock_choir_sim.dsp.super_resolution_estimator import (
-    super_resolution_timing_estimator, SuperResolutionEstimator,
-    SuperResolutionMethod, SuperResolutionConfig
+    estimate_tone_phasors,
+    estimate_noise_power,
+    per_tone_snr,
 )
 from driftlock_choir_sim.dsp.time_delay import impose_fractional_delay_fft
-from driftlock_choir_sim.dsp.impairments import apply_cfo, apply_phase_noise
 from driftlock_choir_sim.dsp.channel_models import awgn
-
-
-OUTPUT_DIR = Path("outputs/phase4_super_resolution")
-FIGURES_DIR = OUTPUT_DIR / "figures"
-
-
-def ensure_output_dirs():
-    """Create output directories if they don't exist."""
-    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
-    FIGURES_DIR.mkdir(parents=True, exist_ok=True)
-
-
-def test_super_resolution_methods():
-    """Test different super-resolution methods."""
-    print("Testing Super-Resolution Methods...")
-
-    # Test parameters for sub-10ps precision
-    fs = 20e6
-    duration = 9e-3
-    df = 1e6
-    m = 21
-    truth_tau = 5e-12  # 5 ps timing offset (sub-10ps target)
-    truth_df = 500e3   # 500 kHz frequency offset
-    n_trials = 100
-
-    methods = [
-        SuperResolutionMethod.MUSIC,
-        SuperResolutionMethod.ESPRIT,
-        SuperResolutionMethod.MATRIX_PENCIL,
-        SuperResolutionMethod.SUBSPACE,
-        SuperResolutionMethod.COMPRESSED_SENSING
-    ]
-
-    results = {method: {'rmse_tau': [], 'rmse_df': [], 'precision_achieved': []}
-               for method in methods}
-
-    for trial in range(n_trials):
-        rng = np.random.default_rng(2025 + trial)
-
-        # Generate test signal
-        x, fk, pilot_mask, _ = generate_comb(
-            fs, duration, df, m=m, omit_fundamental=True, rng=rng, return_payload=True
-        )
-
-        # Apply impairments
-        x = impose_fractional_delay_fft(x, fs, truth_tau)
-        x = apply_cfo(x, fs, truth_df / fs)
-        x = apply_phase_noise(x, 0.0, rng)
-        x = awgn(x, 35.0, rng)  # 35dB SNR for precision testing
-
-        # Estimate phasors and SNR
-        Yk = estimate_tone_phasors(x, fs, fk)
-        noise_power = estimate_noise_power(x, fs, fk, Yk)
-        snr_per_tone = per_tone_snr(Yk, noise_power, len(x))
-
-        # Test each super-resolution method
-        for method in methods:
-            try:
-                tau_est, df_est = super_resolution_timing_estimator(
-                    Yk, fk, method=method, snr=snr_per_tone
-                )
-
-                # Store results
-                results[method]['rmse_tau'].append(abs(tau_est - truth_tau) * 1e12)  # ps
-                results[method]['rmse_df'].append(abs(df_est - truth_df))  # Hz
-                results[method]['precision_achieved'].append(
-                    abs(tau_est - truth_tau) * 1e12 < 10.0  # Sub-10ps achieved
-                )
-
-            except Exception as e:
-                # Count failures
-                results[method]['rmse_tau'].append(1000.0)  # Large error for failures
-                results[method]['rmse_df'].append(1e6)      # Large error for failures
-                results[method]['precision_achieved'].append(False)
-
-    # Calculate statistics
-    summary = {}
-    for method in methods:
-        tau_rmse = np.mean(results[method]['rmse_tau'])
-        df_rmse = np.mean(results[method]['rmse_df'])
-        precision_rate = np.mean(results[method]['precision_achieved']) * 100
-
-        summary[method] = {
-            'tau_rmse_ps': tau_rmse,
-            'df_rmse_hz': df_rmse,
-            'precision_rate_pct': precision_rate,
-            'sub_10ps_achieved': tau_rmse < 10.0
-        }
-
-        method_name = method.value.replace('_', ' ').title()
-        print(f"  {method_name:20s} - τ: {tau_rmse:6.2f} ps, Sub-10ps: {precision_rate:5.1f}%")
-
-    return summary
-
-
-def test_method_comparison():
-    """Compare super-resolution methods against traditional approaches."""
-    print("\nComparing Super-Resolution vs Traditional Methods...")
-
-    # Test parameters
-    fs = 20e6
-    duration = 9e-3
-    df = 1e6
-    m = 21
-    truth_tau = 5e-12
-    n_trials = 50
-
-    # Methods to compare
-    methods = {
-        'traditional_wls': 'Traditional WLS',
-        'music': 'MUSIC Algorithm',
-        'esprit': 'ESPRIT Algorithm',
-        'matrix_pencil': 'Matrix Pencil',
-        'subspace': 'Subspace Method',
-        'compressed_sensing': 'Compressed Sensing'
-    }
-
-    comparison_results = {key: {'rmse_ps': [], 'latency_ms': []}
-                         for key in methods.keys()}
-
-    for trial in range(n_trials):
-        rng = np.random.default_rng(3000 + trial)
-
-        # Generate test signal
-        x, fk, pilot_mask, _ = generate_comb(
-            fs, duration, df, m=m, omit_fundamental=True, rng=rng, return_payload=True
-        )
-
-        # Apply impairments
-        x = impose_fractional_delay_fft(x, fs, truth_tau)
-        x = apply_cfo(x, fs, 0.0)
-        x = apply_phase_noise(x, 0.0, rng)
-        x = awgn(x, 30.0, rng)  # 30dB SNR
-
-        # Estimate phasors and SNR
-        Yk = estimate_tone_phasors(x, fs, fk)
-        noise_power = estimate_noise_power(x, fs, fk, Yk)
-        snr_per_tone = per_tone_snr(Yk, noise_power, len(x))
-
-        # Test traditional method
-        start_time = time.time()
-        tau_traditional, _ = traditional_wls_delay(Yk, fk, snr_per_tone)
-        latency_traditional = (time.time() - start_time) * 1000
-
-        comparison_results['traditional_wls']['rmse_ps'].append(
-            abs(tau_traditional - truth_tau) * 1e12
-        )
-        comparison_results['traditional_wls']['latency_ms'].append(latency_traditional)
-
-        # Test super-resolution methods
-        for method_key, method_name in [
-            ('music', SuperResolutionMethod.MUSIC),
-            ('esprit', SuperResolutionMethod.ESPRIT),
-            ('matrix_pencil', SuperResolutionMethod.MATRIX_PENCIL),
-            ('subspace', SuperResolutionMethod.SUBSPACE),
-            ('compressed_sensing', SuperResolutionMethod.COMPRESSED_SENSING)
-        ]:
-            try:
-                start_time = time.time()
-                tau_sr, _ = super_resolution_timing_estimator(
-                    Yk, fk, method=method_name, snr=snr_per_tone
-                )
-                latency_sr = (time.time() - start_time) * 1000
-
-                comparison_results[method_key]['rmse_ps'].append(
-                    abs(tau_sr - truth_tau) * 1e12
-                )
-                comparison_results[method_key]['latency_ms'].append(latency_sr)
-
-            except Exception as e:
-                # Handle failures
-                comparison_results[method_key]['rmse_ps'].append(1000.0)
-                comparison_results[method_key]['latency_ms'].append(100.0)
-
-    # Calculate statistics
-    comparison_summary = {}
-    for method_key, data in comparison_results.items():
-        avg_rmse = np.mean(data['rmse_ps'])
-        avg_latency = np.mean(data['latency_ms'])
-        sub_10ps_rate = np.mean(np.array(data['rmse_ps']) < 10.0) * 100
-
-        comparison_summary[method_key] = {
-            'avg_rmse_ps': avg_rmse,
-            'avg_latency_ms': avg_latency,
-            'sub_10ps_rate_pct': sub_10ps_rate
-        }
-
-        method_name = methods[method_key]
-        print(f"  {method_name:20s} - RMSE: {avg_rmse:6.2f} ps, Latency: {avg_latency:5.2f} ms, Sub-10ps: {sub_10ps_rate:5.1f}%")
-
-    return comparison_summary
-
-
-def test_robustness_analysis():
-    """Test robustness of super-resolution methods under stress."""
-    print("\nTesting Robustness Under Stress Conditions...")
-
-    # Test parameters
-    fs = 20e6
-    duration = 9e-3
-    df = 1e6
-    m = 21
-    truth_tau = 5e-12
-    n_trials = 50
-
-    # Challenging conditions
-    conditions = {
-        'high_noise': {'snr_db': 15.0, 'phase_noise': 0.1},
-        'multipath': {'snr_db': 25.0, 'multipath_delay': 1e-6},
-        'doppler': {'snr_db': 20.0, 'doppler_shift': 100.0},
-        'interference': {'snr_db': 10.0, 'interference_power': 0.5}
-    }
-
-    methods = [SuperResolutionMethod.MUSIC, SuperResolutionMethod.ESPRIT]
-    robustness_results = {condition: {method: {'success_rate': 0, 'avg_rmse': 0}
-                                     for method in methods}
-                         for condition in conditions.keys()}
-
-    for condition, params in conditions.items():
-        print(f"  Testing {condition}...")
-
-        for trial in range(n_trials):
-            rng = np.random.default_rng(4000 + trial)
-
-            # Generate test signal
-            x, fk, pilot_mask, _ = generate_comb(
-                fs, duration, df, m=m, omit_fundamental=True, rng=rng, return_payload=True
-            )
-
-            # Apply impairments based on condition
-            x = impose_fractional_delay_fft(x, fs, truth_tau)
-            x = apply_cfo(x, fs, 0.0)
-            x = apply_phase_noise(x, params.get('phase_noise', 0.0), rng)
-            x = awgn(x, params['snr_db'], rng)
-
-            # Add condition-specific impairments
-            if condition == 'multipath':
-                x_multipath = np.roll(x, int(params['multipath_delay'] * fs))
-                x = x + 0.3 * x_multipath
-            elif condition == 'doppler':
-                t = np.arange(len(x)) / fs
-                doppler_phase = 2 * np.pi * params['doppler_shift'] * t**2 / 2
-                x = x * np.exp(1j * doppler_phase)
-            elif condition == 'interference':
-                interference = np.random.randn(len(x)) + 1j * np.random.randn(len(x))
-                interference = interference / np.sqrt(2) * np.sqrt(params['interference_power'])
-                x = x + interference
-
-            # Estimate phasors and SNR
-            Yk = estimate_tone_phasors(x, fs, fk)
-            noise_power = estimate_noise_power(x, fs, fk, Yk)
-            snr_per_tone = per_tone_snr(Yk, noise_power, len(x))
-
-            # Test each method
-            for method in methods:
-                try:
-                    tau_est, _ = super_resolution_timing_estimator(
-                        Yk, fk, method=method, snr=snr_per_tone
-                    )
-
-                    rmse_ps = abs(tau_est - truth_tau) * 1e12
-                    success = rmse_ps < 50.0  # 50ps threshold for success
-
-                    robustness_results[condition][method]['success_rate'] += success
-                    robustness_results[condition][method]['avg_rmse'] += rmse_ps
-
-                except Exception as e:
-                    robustness_results[condition][method]['success_rate'] += 0
-
-        # Calculate final statistics
-        for method in methods:
-            robustness_results[condition][method]['success_rate'] /= n_trials
-            robustness_results[condition][method]['avg_rmse'] /= n_trials
-
-            method_name = method.value.replace('_', ' ').title()
-            success_rate = robustness_results[condition][method]['success_rate'] * 100
-            avg_rmse = robustness_results[condition][method]['avg_rmse']
-            print(f"    {method_name:15s} - Success: {success_rate:5.1f}%, RMSE: {avg_rmse:6.2f} ps")
-
-    return robustness_results
-
-
-def plot_super_resolution_results(sr_results, comparison_results, robustness_results):
-    """Generate super-resolution performance plots."""
-    print("\nGenerating Super-Resolution Performance Plots...")
-
-    # Method comparison plot
-    fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(15, 6))
-
-    methods = list(sr_results.keys())
-    method_names = [method.value.replace('_', ' ').title() for method in methods]
-    rmse_values = [sr_results[method]['tau_rmse_ps'] for method in methods]
-    precision_rates = [sr_results[method]['precision_rate_pct'] for method in methods]
-
-    # RMSE comparison
-    bars1 = ax1.bar(method_names, rmse_values, color=['#FF6B6B', '#4ECDC4', '#45B7D1', '#96CEB4', '#FFEAA7'])
-    ax1.set_ylabel('RMSE (ps)')
-    ax1.set_title('Super-Resolution Method Performance')
-    ax1.axhline(y=10.0, color='r', linestyle='--', alpha=0.7, label='10ps Target')
-    ax1.axhline(y=5.0, color='g', linestyle='--', alpha=0.7, label='5ps Breakthrough')
-    ax1.legend()
-    ax1.grid(True, alpha=0.3)
-    ax1.tick_params(axis='x', rotation=45)
-
-    # Add value labels
-    for bar, rmse in zip(bars1, rmse_values):
-        height = bar.get_height()
-        ax1.text(bar.get_x() + bar.get_width()/2., height + 0.1,
-                f'{rmse:.2f}', ha='center', va='bottom', fontsize=10)
-
-    # Precision achievement rate
-    bars2 = ax2.bar(method_names, precision_rates, color=['#FF6B6B', '#4ECDC4', '#45B7D1', '#96CEB4', '#FFEAA7'])
-    ax2.set_ylabel('Sub-10ps Achievement Rate (%)')
-    ax2.set_title('Precision Success Rate')
-    ax2.axhline(y=90.0, color='g', linestyle='--', alpha=0.7, label='90% Target')
-    ax2.legend()
-    ax2.grid(True, alpha=0.3)
-    ax2.tick_params(axis='x', rotation=45)
-
-    for bar, rate in zip(bars2, precision_rates):
-        height = bar.get_height()
-        ax2.text(bar.get_x() + bar.get_width()/2., height + 1,
-                f'{rate:.1f}%', ha='center', va='bottom', fontsize=10)
-
-    plt.tight_layout()
-    plt.savefig(FIGURES_DIR / 'phase4_super_resolution_methods.png', dpi=300, bbox_inches='tight')
-    plt.close()
-
-    # Traditional vs Super-resolution comparison
-    fig, ax = plt.subplots(figsize=(12, 6))
-
-    method_keys = list(comparison_results.keys())
-    method_names = ['Traditional WLS', 'MUSIC', 'ESPRIT', 'Matrix Pencil', 'Subspace', 'Compressed Sensing']
-    rmse_values = [comparison_results[key]['avg_rmse_ps'] for key in method_keys]
-    latency_values = [comparison_results[key]['avg_latency_ms'] for key in method_keys]
-
-    colors = ['#666666', '#FF6B6B', '#4ECDC4', '#45B7D1', '#96CEB4', '#FFEAA7']
-
-    bars = ax.bar(method_names, rmse_values, color=colors)
-    ax.set_ylabel('Average RMSE (ps)')
-    ax.set_title('Traditional vs Super-Resolution Methods')
-    ax.axhline(y=10.0, color='r', linestyle='--', alpha=0.7, label='10ps Target')
-    ax.legend()
-    ax.grid(True, alpha=0.3)
-    ax.tick_params(axis='x', rotation=45)
-
-    # Add value labels
-    for bar, rmse in zip(bars, rmse_values):
-        height = bar.get_height()
-        ax.text(bar.get_x() + bar.get_width()/2., height + 0.1,
-                f'{rmse:.2f}', ha='center', va='bottom', fontsize=10)
-
-    plt.tight_layout()
-    plt.savefig(FIGURES_DIR / 'phase4_method_comparison.png', dpi=300, bbox_inches='tight')
-    plt.close()
-
-    # Robustness comparison plot
-    fig, ax = plt.subplots(figsize=(10, 6))
-
-    conditions = list(robustness_results.keys())
-    condition_names = [cond.replace('_', ' ').title() for cond in conditions]
-
-    methods = list(list(robustness_results.values())[0].keys())
-    method_names = [method.value.replace('_', ' ').title() for method in methods]
-
-    x = np.arange(len(conditions))
-    width = 0.35
-
-    for i, method in enumerate(methods):
-        success_rates = [robustness_results[cond][method]['success_rate'] * 100
-                        for cond in conditions]
-        ax.bar(x + i*width, success_rates, width,
-               label=method_names[i], alpha=0.8)
-
-    ax.set_xlabel('Test Condition')
-    ax.set_ylabel('Success Rate (%)')
-    ax.set_title('Robustness Under Stress Conditions')
-    ax.set_xticks(x + width/2)
-    ax.set_xticklabels(condition_names)
-    ax.legend()
-    ax.grid(True, alpha=0.3)
-    ax.axhline(y=80.0, color='g', linestyle='--', alpha=0.7, label='80% Target')
-
-    plt.tight_layout()
-    plt.savefig(FIGURES_DIR / 'phase4_robustness_analysis.png', dpi=300, bbox_inches='tight')
-    plt.close()
-
-
-def generate_super_resolution_report(all_results):
-    """Generate comprehensive super-resolution performance report."""
-    print("\n" + "="*70)
-    print("PHASE 4 SUPER-RESOLUTION PERFORMANCE REPORT")
-    print("="*70)
-
-    sr_results = all_results['super_resolution']
-    comparison = all_results['comparison']
-    robustness = all_results['robustness']
-
-    print("\n1. SUPER-RESOLUTION METHOD COMPARISON:")
-    print("   Target: Achieve sub-10ps timing precision with >90% success rate")
-
-    best_method = max(sr_results.keys(),
-                     key=lambda k: sr_results[k]['precision_rate_pct'])
-    best_rate = sr_results[best_method]['precision_rate_pct']
-    best_rmse = sr_results[best_method]['tau_rmse_ps']
-
-    print(f"   Best Method: {best_method.value.replace('_', ' ').title()}")
-    print(f"   Average RMSE: {best_rmse:.2f} ps")
-    print(f"   Sub-10ps Success Rate: {best_rate:.1f}%")
-    print(f"   Target Achievement: {'✅ SUCCESS' if best_rate >= 90 else '⚠️ NEEDS_WORK'}")
-
-    print("\n2. TRADITIONAL vs SUPER-RESOLUTION:")
-    traditional_rmse = comparison['traditional_wls']['avg_rmse_ps']
-    best_sr_rmse = min([comp['avg_rmse_ps'] for comp in comparison.values() if comp['avg_rmse_ps'] < 1000])
-
-    print(f"   Traditional WLS RMSE: {traditional_rmse:.2f} ps")
-    print(f"   Best Super-Resolution RMSE: {best_sr_rmse:.2f} ps")
-    print(f"   Improvement: {((traditional_rmse - best_sr_rmse) / traditional_rmse * 100):.1f}%")
-
-    print("\n3. ROBUSTNESS ANALYSIS:")
-    print("   Testing performance under challenging conditions:")
-
-    for condition, methods in robustness.items():
-        condition_name = condition.replace('_', ' ').title()
-        print(f"   {condition_name}:")
-
-        for method_key, stats in methods.items():
-            method_name = method_key.value.replace('_', ' ').title()
-            success_rate = stats['success_rate'] * 100
-            avg_rmse = stats['avg_rmse']
-            print(f"     {method_name:15s} - Success: {success_rate:5.1f}%, RMSE: {avg_rmse:6.2f} ps")
-
-    print("\n4. TECHNICAL ACHIEVEMENTS:")
-    print("   ✅ MUSIC (Multiple Signal Classification) algorithm")
-    print("   ✅ ESPRIT (Estimation of Signal Parameters via Rotational Invariance)")
-    print("   ✅ Matrix pencil method for enhanced frequency resolution")
-    print("   ✅ Subspace-based methods for improved timing estimation")
-    print("   ✅ Compressed sensing approaches for sparse signal reconstruction")
-    print("   ✅ Comparative analysis against traditional methods")
-
-    print("\n5. PERFORMANCE BREAKTHROUGHS:")
-    sub_10ps_achieved = any(data['precision_rate_pct'] >= 90 for data in sr_results.values())
-    improvement_over_traditional = (traditional_rmse - best_sr_rmse) / traditional_rmse > 0.1
-
-    if sub_10ps_achieved:
-        print("   🎉 SUB-10PS PRECISION ACHIEVED!")
-    else:
-        print("   ⚠️  Sub-10ps precision needs further optimization")
-
-    if improvement_over_traditional:
-        print("   📈 SIGNIFICANT IMPROVEMENT OVER TRADITIONAL METHODS!")
-    else:
-        print("   ⚠️  Limited improvement over traditional methods")
-
-    print("\n6. NEXT STEPS:")
-    if sub_10ps_achieved:
-        print("   • Continue to Phase 5: System integration and real-time optimization")
-        print("   • Implement hardware acceleration for super-resolution methods")
-        print("   • Develop adaptive method selection based on conditions")
-    else:
-        print("   • Optimize super-resolution algorithm parameters")
-        print("   • Enhance noise robustness of subspace methods")
-        print("   • Develop hybrid traditional/super-resolution approaches")
-
-    print("="*70)
-
-
-def main():
-    """Run all Phase 4 super-resolution tests."""
-    print("Driftlock Phase 4: Super-Resolution Performance")
-    print("Testing advanced signal processing techniques for sub-10ps precision...")
-
-    start_time = time.time()
-    ensure_output_dirs()
-
-    # Run all tests
-    all_results = {}
-
-    all_results['super_resolution'] = test_super_resolution_methods()
-    all_results['comparison'] = test_method_comparison()
-    all_results['robustness'] = test_robustness_analysis()
-
-    # Generate plots
-    plot_super_resolution_results(
-        all_results['super_resolution'],
-        all_results['comparison'],
-        all_results['robustness']
+from driftlock_choir_sim.dsp.super_resolution_estimator import (
+    SuperResolutionConfig,
+    SuperResolutionEstimator,
+    SuperResolutionMethod,
+)
+
+
+def _snapshot() -> tuple[np.ndarray, np.ndarray, np.ndarray, float]:
+    fs = 500_000.0
+    duration = 0.003
+    df = 10_000.0
+    m = 7
+    truth_tau = 30e-9
+    rng = np.random.default_rng(444)
+
+    x, fk, *_ = generate_comb(
+        fs,
+        duration,
+        df,
+        m=m,
+        omit_fundamental=True,
+        rng=rng,
+        return_payload=False,
+    )
+    x = impose_fractional_delay_fft(x, fs, truth_tau)
+    x = awgn(x, 30.0, rng)
+
+    phasors = estimate_tone_phasors(x, fs, fk)
+    noise_power = estimate_noise_power(x, fs, fk, phasors)
+    snr = per_tone_snr(phasors, noise_power, len(x))
+    return fk, phasors, snr, fs
+
+
+def test_compressed_sensing_super_resolution_returns_metadata() -> None:
+    fk, phasors, snr, fs = _snapshot()
+    config = SuperResolutionConfig(
+        method=SuperResolutionMethod.COMPRESSED_SENSING,
+        n_sources=2,
+        n_snapshots=5,
+        threshold_db=-20.0,
+    )
+    estimator = SuperResolutionEstimator(fs=fs, config=config)
+    tau_est, df_est, stats = estimator.estimate_timing(
+        phasors,
+        fk,
+        snr,
+        return_stats=True,
     )
 
-    # Generate comprehensive report
-    generate_super_resolution_report(all_results)
-
-    # Save detailed results
-    import json
-    results_file = OUTPUT_DIR / 'phase4_super_resolution_results.json'
-
-    def serialize_for_json(obj):
-        """Convert non-serializable objects to strings for JSON."""
-        if hasattr(obj, 'value'):
-            return obj.value  # Convert enum to string
-        if isinstance(obj, (np.ndarray, np.integer, np.floating)):
-            return obj.item() if hasattr(obj, 'item') else float(obj)
-        if str(type(obj)) == "<class 'driftlock_choir_sim.dsp.super_resolution_estimator.SuperResolutionMethod'>":
-            return obj.value  # Handle SuperResolutionMethod enum specifically
-        return str(obj)
-
-    with open(results_file, 'w') as f:
-        json.dump(all_results, f, indent=2, default=serialize_for_json)
-
-    elapsed_time = time.time() - start_time
-    print(f"\nSuper-resolution validation completed in {elapsed_time:.1f} seconds")
-    print(f"Results saved to: {results_file}")
-    print(f"Figures saved to: {FIGURES_DIR}")
-
-
-if __name__ == "__main__":
-    main()
+    assert np.isfinite(tau_est)
+    assert np.isfinite(df_est)
+    assert stats["method"] == SuperResolutionMethod.COMPRESSED_SENSING.value
+    assert stats["n_sources_detected"] == config.n_sources
+    assert 0.0 <= stats["confidence"] <= 1.0
+    assert np.isfinite(stats["snr_db"])

--- a/driftlock_choir_sim/viz/compositor.py
+++ b/driftlock_choir_sim/viz/compositor.py
@@ -5,10 +5,9 @@ from pathlib import Path
 from typing import Optional
 
 import matplotlib.pyplot as plt
-from matplotlib.animation import FuncAnimation
+from matplotlib.animation import FFMpegWriter, FuncAnimation, PillowWriter, writers
 import numpy as np
 import yaml
-from matplotlib.animation import FFMpegWriter, FuncAnimation
 
 # Import simulation modules (assuming PYTHONPATH=.)
 from driftlock_choir_sim.dsp.tx_comb import generate_comb
@@ -131,11 +130,19 @@ def animate_split_screen(baseline_config: dict, demo_config: dict, num_frames: i
             ax_right.text(0.05, 0.95, f"τ̂: {data['tau_ps']:.1f} ps | SNR: {data['df_snr_db']:.1f} dB", transform=ax_right.transAxes, fontsize=10,
                           bbox=dict(boxstyle="round", facecolor="white", alpha=0.8))
 
-    ani = FuncAnimation(fig, update, frames=num_frames, interval=1000/24, blit=False)
+    ani = FuncAnimation(fig, update, frames=num_frames, interval=1000 / 24, blit=False)
     output_dir = Path("driftlock_choir_sim/outputs/comparisons/side_by_side")
     output_dir.mkdir(parents=True, exist_ok=True)
-    ani.save(output_dir / "comparison.mp4", writer=FFMpegWriter(fps=24))
-    print(f"Animated split-screen saved to {output_dir / 'comparison.mp4'}")
+
+    if writers.is_available("ffmpeg"):
+        video_path = output_dir / "comparison.mp4"
+        writer = FFMpegWriter(fps=24)
+    else:
+        video_path = output_dir / "comparison.gif"
+        writer = PillowWriter(fps=24)
+
+    ani.save(video_path, writer=writer)
+    print(f"Animated split-screen saved to {video_path}")
 
     # Spritesheet
     grid_cols = max(1, num_frames // 10)
@@ -150,6 +157,9 @@ def animate_split_screen(baseline_config: dict, demo_config: dict, num_frames: i
         axs[1, col].plot(demo_data["f_env_khz"][:100], demo_data["env_db"][:100])
     plt.savefig(output_dir / "spritesheet.png", dpi=100)
     print(f"Spritesheet saved to {output_dir / 'spritesheet.png'}")
+
+    # Provide the caller with the generated animation path so tests can assert on it.
+    return video_path
 
 def main():
     parser = argparse.ArgumentParser(description="Create split-screen comparison reel.")

--- a/tests/viz/test_compositor.py
+++ b/tests/viz/test_compositor.py
@@ -33,14 +33,11 @@ def test_compositor_headless():
             yaml.dump(demo_cfg, f)
 
         # Run with 3 frames
-        animate_split_screen(baseline_cfg, demo_cfg, num_frames=3, seed=2025)
+        video_path = animate_split_screen(baseline_cfg, demo_cfg, num_frames=3, seed=2025)
 
-        # Check if output files exist
-        output_dir = Path("driftlock_choir_sim/outputs/comparisons/side_by_side")
-        assert (output_dir / "comparison.mp4").exists()
-
-        # Basic check: files not empty
-        assert (output_dir / "comparison.mp4").stat().st_size > 0
+        # Check if output file exists and has some content
+        assert video_path.exists()
+        assert video_path.stat().st_size > 0
 
 if __name__ == "__main__":
     test_compositor_headless()


### PR DESCRIPTION
## Summary
- add a root-level pytest hook so the src/ and simulation packages import without installation
- replace the long-form simulation scripts with fast unit checks that exercise CRLB, WLS, closed-form, ultra-precision, and super-resolution paths
- fall back to a Pillow writer when ffmpeg is unavailable and return the generated animation path for verification

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d33104a1588327b108adbcc6b24615